### PR TITLE
Features to customize exported presentations

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -168,6 +168,15 @@ $ git clone https://github.com/yjwen/org-reveal.git
 
     Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
 
+** Extra Stylesheets
+
+    Set =REVEAL_EXTRA_CSS= to a stylesheet file path in order to load extra custom
+    styles after loading a theme.
+
+#+BEGIN_SRC org
+ #+REVEAL_EXTRA_CSS: my-custom-stylesheet.css
+#+END_SRC
+
 ** Fragmented Contents
 
     Make contents fragmented (show up one-by-one) by setting option =ATTR_REVEAL= with

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -50,6 +50,7 @@
     (:reveal-trans "REVEAL_TRANS" nil org-reveal-transition t)
     (:reveal-speed "REVEAL_SPEED" nil org-reveal-transition-speed t)
     (:reveal-theme "REVEAL_THEME" nil org-reveal-theme t)
+    (:reveal-extra-css "REVEAL_EXTRA_CSS" nil nil nil)
     (:reveal-hlevel "REVEAL_HLEVEL" nil nil t)
     (:reveal-mathjax nil "reveal_mathjax" org-reveal-mathjax t)
     (:reveal-mathjax-url "REVEAL_MATHJAX_URL" nil org-reveal-mathjax-url t)
@@ -271,7 +272,7 @@ to form a legal path name."
        (cdr pathes))
     dir-name))
 
-  
+
 (defun org-reveal-stylesheets (info)
   "Return the HTML contents for declaring reveal stylesheets
 using custom variable `org-reveal-root'."
@@ -280,10 +281,15 @@ using custom variable `org-reveal-root'."
          (min-css-file-name (org-reveal--append-path css-dir-name "reveal.min.css"))
          (theme-file (format "%s.css" (plist-get info :reveal-theme)))
          (theme-path (org-reveal--append-path css-dir-name "theme"))
-         (theme-full (org-reveal--append-path theme-path theme-file)))
+         (theme-full (org-reveal--append-path theme-path theme-file))
+         (extra-css (plist-get info :reveal-extra-css))
+         (extra-css-link-tag (if extra-css
+                                 (format "<link rel=\"stylesheet\" href=\"./%s\">" extra-css)
+                               "")))
     (format "<link rel=\"stylesheet\" href=\"%s\">
-<link rel=\"stylesheet\" href=\"%s\" id=\"theme\">\n"
-                min-css-file-name theme-full)))
+<link rel=\"stylesheet\" href=\"%s\" id=\"theme\">
+%s\n"
+                min-css-file-name theme-full extra-css-link-tag)))
 
 (defun org-reveal-mathjax-scripts (info)
   "Return the HTML contents for declaring MathJax scripts"


### PR DESCRIPTION
I made two changes:
1. Added support for several initialization options from reveal.js, especially for turning off the rolling links.
2. Added an org option to load an extra stylesheet file to customize existing themes. While reveal.js generally looks nice, it can use some help here and there.
