### PR TITLE
Removing the unnecessary Markdown README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,0 @@
-org-reveal
-==========
-
-Exports Org-mode contents to Reveal.js HTML presentation.
-
-For detail instruction, please see Readme.org.


### PR DESCRIPTION
Can I suggest you delete README.md? If you do, Github will happily use the Readme.org file on the front page instead. :-)
