### PR TITLE
Fixing a bug with export to PDF.

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -353,7 +353,7 @@ using custom variable `org-reveal-root'."
     (format "<link rel=\"stylesheet\" href=\"%s\"/>
 <link rel=\"stylesheet\" href=\"%s\" id=\"theme\"/>
 %s
-<link rel=\"stylesheet\" href=\"%s\" type=\"text/css\" media=\"print\"/>
+<link rel=\"stylesheet\" href=\"%s\" type=\"text/css\"/>
 "
                 min-css-file-name theme-full extra-css-link-tag
                 pdf-css)))


### PR DESCRIPTION
Chrome 33 caused (revealed?) a bug in the PDF export code. This was
fixed in reveal.js issue 808:

 https://github.com/hakimel/reveal.js/issues/808

This commit mirrors that fix for org-reveal.
