### PR TITLE
fixed pdf export issue

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -361,7 +361,16 @@ using custom variable `org-reveal-root'."
     (format "<link rel=\"stylesheet\" href=\"%s\"/>
 <link rel=\"stylesheet\" href=\"%s\" id=\"theme\"/>
 %s
-<link rel=\"stylesheet\" href=\"%s\" type=\"text/css\" media=\"print\"/>
+<!-- If the query includes 'print-pdf', include the PDF print sheet -->
+<script>
+    if( window.location.search.match( /print-pdf/gi ) ) {
+        var link = document.createElement( 'link' );
+        link.rel = 'stylesheet';
+        link.type = 'text/css';
+        link.href = '%s';
+        document.getElementsByTagName( 'head' )[0].appendChild( link );
+    }
+</script>
 "
                 min-css-file-name theme-full extra-css-link-tag
                 pdf-css)))


### PR DESCRIPTION
I implement the fix in https://github.com/hakimel/reveal.js/issues/808.
This commit requires the use of a ?print-pdf modifier to the URL as detailed in
the issue above.

The other pull request: https://github.com/yjwen/org-reveal/pull/44 loads the `pdf.css` file by default regardless of media type, which overrides the typical css files for presenting. This commit only loads the pdf css, when `?print-pdf` is appended to the url, as done in Issue #808 above.
