### PR TITLE
Added note about optional htmlize.el dependency

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -30,6 +30,7 @@
   - Reveal.js.
   - Latest org-mode.
   - ox-reveal.el.
+  - htmlize.el (optional, for syntax highlighting).
   - And, of course, emacs.
 
 ** Obtain Reveal.js


### PR DESCRIPTION
I just spent several hours trying to get syntax highlighting working in my presentations, and it turns out that all I needed to do was install htmlize.el. Hopefully this patch will save other people from doing the same!
