### PR TITLE
Fixes missing org-html-format-headline--wrap error due to org-mode commi...

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -283,7 +283,7 @@ holding contextual information."
 	 (priority (and (plist-get info :with-priority)
 			(org-element-property :priority headline)))
 	 ;; Create the headline text.
-	 (full-text (org-html-format-headline--wrap headline info)))
+	 (full-text (org-html-headline headline nil info)))
     (cond
      ;; Case 1: This is a footnote section: ignore it.
      ((org-element-property :footnote-section-p headline) nil)


### PR DESCRIPTION
...t: c9ca0b6df86de13a5302b5a3c955fb2fb1023d36

Sorry if I'm missing something (I'm new to elisp) but it looks like org-mode renamed this function recently so if you use their latest version org-reveal export will not work. This fixes that error and is working for me on the newest version of org-mode.
