### PR TITLE
added publishing function for websites

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -752,6 +752,19 @@ info is a plist holding export options."
   (interactive)
   (browse-url-of-file (expand-file-name (org-reveal-export-to-html async subtreep visible-only body-only ext-plist))))
 
+;;;###autoload
+(defun org-reveal-publish-to-reveal
+ (plist filename pub-dir)
+  "Publish an org file to Html.
+
+FILENAME is the filename of the Org file to be published.  PLIST
+is the property list for the given project.  PUB-DIR is the
+publishing directory.
+
+Return output file name."
+  (org-publish-org-to 'reval filename ".html" plist pub-dir))
+
+
 (provide 'ox-reveal)
 
 ;;; ox-reveal.el ends here


### PR DESCRIPTION
I added a publishing function so that org-reveal can published to websites.  See for example the tutorial on publishing with org-mode and Jekyll (http://orgmode.org/worg/org-tutorials/org-jekyll.html).  This closes #84
