### PR TITLE
Removed min from revealjs file names

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -400,7 +400,7 @@ using custom variable `org-reveal-root'."
     (concat
      ;; stylesheets
      (format "
-<link rel=\"stylesheet\" href=\"%scss/reveal.min.css\"/>
+<link rel=\"stylesheet\" href=\"%scss/reveal.css\"/>
 <link rel=\"stylesheet\" href=\"%scss/theme/%s.css\" id=\"theme\"/>
 "
              root-path root-path
@@ -436,10 +436,10 @@ custom variable `org-reveal-root'."
   (let* ((root-path (file-name-as-directory (plist-get info :reveal-root))))
     (concat
      ;; reveal.js/lib/js/head.min.js
-     ;; reveal.js/js/reveal.min.js
+     ;; reveal.js/js/reveal.js
      (format "
 <script src=\"%slib/js/head.min.js\"></script>
-<script src=\"%sjs/reveal.min.js\"></script>
+<script src=\"%sjs/reveal.js\"></script>
 "
              root-path root-path)
      ;; plugin headings


### PR DESCRIPTION
From the current [reveal.js](https://github.com/hakimel/reveal.js/commit/ce8ea8439305913a9be6322fcd445814c521e724) I found that the file names needed to change as noted in the diff.  And I made the change to the stable branch since I am using the current stable version of Org-mode 8.2.10.