### PR TITLE
Make postamble output within the reveal div

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -320,7 +320,7 @@ holding contextual information."
          (priority (and (plist-get info :with-priority)
                         (org-element-property :priority headline)))
          ;; Create the headline text.
-	 (full-text (org-html-format-headline--wrap headline info)))
+         (full-text (org-html-format-headline--wrap headline info)))
     (cond
      ;; Case 1: This is a footnote section: ignore it.
      ((org-element-property :footnote-section-p headline) nil)
@@ -815,9 +815,9 @@ info is a plist holding export options."
        "\n</section>\n")
      "")
    contents
-   "</div>
-</div>\n"
+   "</div>"
    (org-reveal--build-pre/postamble 'postamble info)
+"</div>\n"
    (org-reveal-scripts info)
    "</body>
 </html>\n"))


### PR DESCRIPTION
I'm using ox-reveal from Melpa

I might be misunderstanding something but I expected that setting #+REVEAL_POSTAMBLE would allow me to output some html at the bottom of the page. A "footer" essentially.

When I first tried doing so nothing appeared on the page. I noticed that my POSTAMBLE was appearing outside of the main page div so I modified ox-reveal.el and it now works as I expect.

I have not tested with the master branch to see if that has already made changes in that area.

What do you think?