### PR TITLE
Update mathjax url

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -257,7 +257,7 @@ can contain the following escaping elements:
   :type 'boolean)
 
 (defcustom org-reveal-mathjax-url
-  "http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
+  "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
   "Default MathJax URL."
   :group 'org-export-reveal
   :type 'string)


### PR DESCRIPTION
When uploading slide to web(say github pages), if site is using https, this wont load as it is using http.