### PR TITLE
Add org-reveal-extra-css defcustom

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -59,7 +59,7 @@
     (:reveal-trans "REVEAL_TRANS" nil org-reveal-transition t)
     (:reveal-speed "REVEAL_SPEED" nil org-reveal-transition-speed t)
     (:reveal-theme "REVEAL_THEME" nil org-reveal-theme t)
-    (:reveal-extra-css "REVEAL_EXTRA_CSS" nil nil nil)
+    (:reveal-extra-css "REVEAL_EXTRA_CSS" nil org-reveal-extra-css nil)
     (:reveal-extra-js "REVEAL_EXTRA_JS" nil org-reveal-extra-js nil)
     (:reveal-hlevel "REVEAL_HLEVEL" nil nil t)
     (:reveal-title-slide nil "reveal_title_slide" org-reveal-title-slide t)
@@ -161,6 +161,12 @@ can contain the following escaping elements:
 (defcustom org-reveal-extra-js
   ""
   "URL to extra JS file."
+  :group 'org-export-reveal
+  :type 'string)
+
+(defcustom org-reveal-css-js
+  ""
+  "URL to extra css file."
   :group 'org-export-reveal
   :type 'string)
 

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -164,7 +164,7 @@ can contain the following escaping elements:
   :group 'org-export-reveal
   :type 'string)
 
-(defcustom org-reveal-css-js
+(defcustom org-reveal-extra-css
   ""
   "URL to extra css file."
   :group 'org-export-reveal


### PR DESCRIPTION
By analogy with org-reveal-extra-js, this defcustom lets the URL for extra CSS be set for all presentations.  

I use it this way:

```elisp
(defun mwp-org-reveal-publish-to-html (plist filename pub-dir)
  "Publish an org file to reveal.js HTML Presentation.
FILENAME is the filename of the Org file to be published.  PLIST
is the property list for the given project.  PUB-DIR is the
publishing directory. Returns output file name."
  (let ((org-deck-base-url "http://sandbox.hackinghistory.ca/Tools/deck.js/")
        (org-reveal-root "http://sandbox.hackinghistory.ca/Tools/reveal.js/")
        (org-reveal-extra-css "http://sandbox.hackinghistory.ca/Tools/reveal.js/css/local.css"))
        (org-publish-org-to 'reveal filename ".html" plist pub-dir))

  )
```

And then I add this to my org-publish-project-alist:
```elisp
 	("rlg231-lecture-slides"
	 :base-directory "~/RLG231/Lectures/"
	 :base-extension "org"
	 :publishing-directory "/ssh:matt@shimano:/var/www/sandbox/RLG231/Lectures/Slides"
	 :recursive t
	 :publishing-function mwp-org-reveal-publish-to-html
	 :headline-levels 4             ; Just the default for this project.
         :exclude "LectureOutlines.org"
	 :exclude-tags note noexport
	 :auto-preamble t)
```

What do you think?