### PR TITLE
Don't use subr-x function

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -422,7 +422,7 @@ holding contextual information."
              (let ((attrs
                     (org-html--make-attribute-string
                      `(:data-transition ,(org-element-property :REVEAL_DATA_TRANSITION headline)))))
-               (if (string-empty-p attrs)
+               (if (string= attrs "")
                    "<section>\n"
                  (format "<section %s>\n" attrs))))
          ;; Start a new slide.


### PR DESCRIPTION
The `subr-x` library wasn't properly required, so the previous patch for `data-transition`
didn't work with a compiled ox-reveal. Now we simply inline the
definition of `string-empty-p` ourselves as it is trivial.