### PR TITLE
REVEAL_INIT_SCRIPT didn't work if reveal_single_file was set

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -684,9 +684,9 @@ dependencies: [
                   (append (list extra-codes) builtin-codes))))
           (mapconcat 'identity total-codes ",\n"))
         "]\n"
+         ))
         (let ((init-script (plist-get info :reveal-init-script)))
-          (if init-script (concat "," init-script)))
-        ))
+          (if init-script (concat (if in-single-file "" ",") init-script)))
      "});\n</script>\n")))
 
 (defun org-reveal-toc (depth info)


### PR DESCRIPTION
This patch solves an issue when in-single-file is set. Previously, this setting makes the export to ignore :reveal-init-script.