### PR TITLE
test if image is a file before trying to embed

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -838,6 +838,7 @@ CONTENTS is nil. INFO is a plist holding contextual information."
 the result is the Data URIs of the referenced image."
   (let* ((want-embed-image (and (plist-get info :reveal-single-file)
                                 (plist-get info :html-inline-images)
+                                (s-equals-p "file" (org-element-property :type link))
                                 (org-export-inline-image-p
                                  link (plist-get info :html-inline-image-rules))))
          (raw-path (org-element-property :path link))


### PR DESCRIPTION
a one line fix to allow export when http(s) image links are present.