### PR TITLE
Fix title escape character

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -231,7 +231,7 @@
     To customize the title slide, please set ~org-reveal-title-slide~
     to a string of HTML markups. The following escaping character can
     be used to retrieve document information:
-    | ~%s~ | Title     |
+    | ~%t~ | Title     |
     | ~%a~ | Author    |
     | ~%e~ | Email     |
     | ~%d~ | Date      |


### PR DESCRIPTION
I'm using org-reveal for a presentation and I noticed that %s doesn't work to refer to the document's title. %t is the correct escape character.