### PR TITLE
External plugins

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -471,6 +471,12 @@
       =org-reveal-history=, =org-reveal-center=, =org-reveal-rolling-links=, =org-reveal-keyboard=, =org-reveal-overview=
 
     For an example, please refer to the heading part of this document.
+
+** Third-Party Plugins
+Reveal.js is also extensible through third-party plugins. Org-reveal now includes a mechanism to load these as well. It's a little more complicated, because we need to store the specific javascript loading code in a defcustom.
+
+Store the names and loading instructions for each plugin in the defcustom ~org-reveal-external-plugins~. This defcustom is an associative list. The first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}'.  If you need the async or callback parameters, include those too.  Ox-reveal will add the plugin to the dependencies parameter when Reveal is initialized.  
+
 ** Highlight Source Code
 
    There are two ways to highlight source code.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -335,13 +335,13 @@ content."
           (const multiplex)))
 
 (defcustom org-reveal-external-plugins nil
-  "Additional third-party Plugins to load with reveal. Each entry
-  should contain a name and an expression of the form 
-  \"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
-  Note that some plugins have dependencies such as jquery; these must be included here as well, 
-  BEFORE the plugins that depend on them."
+  "Additional third-party Plugins to load with reveal. 
+Each entry should contain a name and an expression of the form 
+\"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
+Note that some plugins have dependencies such as jquery; these must be included here as well, 
+BEFORE the plugins that depend on them."
   :group 'org-rexport-reveal
-  :type 'plist)
+  :type 'alist)
 
 (defcustom org-reveal-single-file nil
   "Export presentation into one single HTML file, which embedded
@@ -729,10 +729,14 @@ dependencies: [
                                          (wrong-type-argument nil))))
                    (or (and buffer-plugins (listp buffer-plugins) buffer-plugins)
                        org-reveal-plugins))))
+               (external-plugins
+                (cl-loop for (key . value) in org-reveal-external-plugins
+                         collect (format  value root-path )) )
+               (all-plugins (if external-plugins (append external-plugins builtin-codes) builtin-codes))
                (extra-codes (plist-get info :reveal-extra-js))
                (total-codes
-                (if (string= "" extra-codes) builtin-codes
-                  (append (list extra-codes) builtin-codes))))
+                (if (string= "" extra-codes) all-plugins (append (list extra-codes) all-plugins))                ))
+          (message "external-plugins= %s" external-plugins)
           (mapconcat 'identity total-codes ",\n"))
         "]\n"
          ))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -334,6 +334,15 @@ content."
           (const remotes)
           (const multiplex)))
 
+(defcustom org-reveal-external-plugins nil
+  "Additional third-party Plugins to load with reveal. Each entry
+  should contain a name and an expression of the form 
+  \"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
+  Note that some plugins have dependencies such as jquery; these must be included here as well, 
+  BEFORE the plugins that depend on them."
+  :group 'org-rexport-reveal
+  :type 'plist)
+
 (defcustom org-reveal-single-file nil
   "Export presentation into one single HTML file, which embedded
   JS scripts and pictures."


### PR DESCRIPTION
This branch adds preliminary support for the use of external plugins that are stored somewhere below the root directory of org-reveal.  

