### PR TITLE
Support for live execution of code snippets

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -471,6 +471,12 @@
       =org-reveal-history=, =org-reveal-center=, =org-reveal-rolling-links=, =org-reveal-keyboard=, =org-reveal-overview=
 
     For an example, please refer to the heading part of this document.
+
+** Third-Party Plugins
+Reveal.js is also extensible through third-party plugins. Org-reveal now includes a mechanism to load these as well. It's a little more complicated, because we need to store the specific javascript loading code in a defcustom.
+
+Store the names and loading instructions for each plugin in the defcustom ~org-reveal-external-plugins~. This defcustom is an associative list. The first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}'.  If you need the async or callback parameters, include those too.  Ox-reveal will add the plugin to the dependencies parameter when Reveal is initialized.  
+
 ** Highlight Source Code
 
    There are two ways to highlight source code.

--- a/Readme.org
+++ b/Readme.org
@@ -511,6 +511,13 @@ Store the names and loading instructions for each plugin in the defcustom ~org-r
     The "%r" in the given CSS file name will be replaced by Reveal.js'
     URL.
 
+** Editable Source Code
+It is now possible to embed code blocks in a codemirror instance in order to edit code during a presentation.  At present, this capacity is turned on or off at time export using these defcustoms:
+- ~org-reveal-klipsify-src~
+- ~org-reveal-klipse-css~
+- ~org-reveal-klipse-js~
+TThis feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present couce editing is supported in javacript, clojure, php, ruby, scheme, and pyhton only.  
+
 ** MathJax
   :PROPERTIES:
   :CUSTOM_ID: my-heading

--- a/Readme.org
+++ b/Readme.org
@@ -720,7 +720,7 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    custom-id, as the examples below:
 
    * [[Tips]].
-   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.
+   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.q
 
 ** Custom JS
 
@@ -728,6 +728,25 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    ~#+REVEAL_INIT_SCRIPT~ (multiple statements are concatenated) or by
    custom variable ~org-reveal-init-script~.
 
+** Executable Source Blocks
+To allow live execution of code in some languages, enable the klipsify plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
+
+*** HTML Src Block
+#+BEGIN_SRC html
+<h1 class="whatever">hello, what's your name</h1>
+#+END_SRC
+
+*** Javascript Src Block
+#+BEGIN_SRC js
+console.log("success");
+var x='string using single quote';
+x
+#+END_SRC
+
+*** Perl Src Block (not klipsified)
+#+BEGIN_SRC perl
+I don't know perl!
+#+END_SRC
 * Thanks
 
   Courtesy to:

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -997,6 +997,12 @@ contextual information."
                       (format " id=\"%s\"" lbl))))
            (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
                            (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
+           (langselector (cond ((string= lang "javascript") "selector_eval_js")
+                               ((string= lang "clojure") "selector")
+                               ((string= lang "python") "selector_eval_python_client")
+                               ((string= lang "scheme") "selector_eval_scheme")
+                               ((string= lang "ruby") "selector_eval_ruby"))
+                         )
            ;;(klipse-hidden (if (assoc 'klipse org-reveal-external-plugins) " style=\"display:hidden;\"") nil)
                       )
       (if (not lang)
@@ -1004,6 +1010,7 @@ contextual information."
                   (or (frag-class frag info) " class=\"example\"")
                   label
                   code)
+        (cond ((eq lang "javascript ")))
         (format
          "<div %sclass=\"org-src-container\">\n%s%s\n</div>%s"
          (if klipsify "style=\"display:none;\" " "")
@@ -1019,8 +1026,22 @@ contextual information."
                        (format " class=\"src src-%s\"" lang))
                    label code)
            )
-         (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
-                              lang code) ""))))))
+         ;; (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
+         ;;                      lang code) "")
+         (if klipsify (concat  "<iframe height=\"500px\" width= \"100%\" srcdoc='
+<pre><code class= \"klipse\">
+" code  "
+</code></pre>
+<link rel= \"stylesheet\" type= \"text/css\" href=\"" org-reveal-klipse-css "\">
+<style>
+.CodeMirror { font-size: 2em; }
+</style>
+<script>
+window.klipse_settings = { " langselector  ": \".klipse\" };
+</script>
+<script src= \"" org-reveal-klipse-js "\"></script>
+'>
+</iframe>") "") )))))
 
 (defun org-reveal-quote-block (quote-block contents info)
   "Transcode a QUOTE-BLOCK element from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -371,6 +371,21 @@ BEFORE the plugins that depend on them."
   :group 'org-export-reveal
   :type 'string)
 
+(defcustom org-reveal-klipsify-src nil
+  "Set to non-nil if you would like to make source code blocks editable in exported presentation."
+  :group 'org-export-reveal
+  :type 'boolean)
+
+(defcustom org-reveal-klipse-css "https://storage.googleapis.com/app.klipse.tech/css/codemirror.css"
+  "Location of the codemirror css file for use with klipse."
+  :group 'org-export-reveal
+  :type 'string)
+
+(defcustom org-reveal-klipse-css "https://storage.googleapis.com/app.klipse.tech/js/klipse_plugin.js"
+  "location of the klipse js source code."
+  :group 'org-export-reveal
+  :type 'string)
+
 (defvar org-reveal--last-slide-section-tag ""
   "Variable to cache the section tag from the last slide. ")
 
@@ -995,7 +1010,7 @@ contextual information."
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
                       (format " id=\"%s\"" lbl))))
-           (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
+           (klipsify  (and  org-reveal-klipsify-src ;;(assoc 'klipse org-reveal-external-plugins)
                            (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
            (langselector (cond ((string= lang "javascript") "selector_eval_js")
                                ((string= lang "clojure") "selector")

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -381,7 +381,7 @@ BEFORE the plugins that depend on them."
   :group 'org-export-reveal
   :type 'string)
 
-(defcustom org-reveal-klipse-css "https://storage.googleapis.com/app.klipse.tech/js/klipse_plugin.js"
+(defcustom org-reveal-klipse-js "https://storage.googleapis.com/app.klipse.tech/plugin_prod/js/klipse_plugin.min.js"
   "location of the klipse js source code."
   :group 'org-export-reveal
   :type 'string)
@@ -994,6 +994,9 @@ holding contextual information."
   "Transcode a SRC-BLOCK element from Org to Reveal.
 CONTENTS holds the contents of the item.  INFO is a plist holding
 contextual information."
+  (message  "%s" (plist-get (cadr src-block) :attr_html))
+  (if (org-export-read-attribute :attr_html src-block :data-library)
+      (message "could do something useful here with the data-library element"))
   (if (org-export-read-attribute :attr_html src-block :textarea)
       (org-html--textarea-block src-block)
     (let* ((use-highlight (org-reveal--using-highlight.js info))
@@ -1010,42 +1013,46 @@ contextual information."
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
                       (format " id=\"%s\"" lbl))))
-           (klipsify  (and  org-reveal-klipsify-src ;;(assoc 'klipse org-reveal-external-plugins)
-                           (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
-           (langselector (cond ((string= lang "javascript") "selector_eval_js")
+           (klipsify  (and  org-reveal-klipsify-src 
+                           (member lang '("javascript" "js" "ruby" "scheme" "clojure" "php" "html"))))
+           (langselector (cond ((or (string= lang "js") (string= lang "javascript")) "selector_eval_js")
                                ((string= lang "clojure") "selector")
                                ((string= lang "python") "selector_eval_python_client")
                                ((string= lang "scheme") "selector_eval_scheme")
-                               ((string= lang "ruby") "selector_eval_ruby"))
+                               ((string= lang "ruby") "selector_eval_ruby")
+                               ((string= lang "html") "selector_eval_html"))
                          )
-           ;;(klipse-hidden (if (assoc 'klipse org-reveal-external-plugins) " style=\"display:hidden;\"") nil)
-                      )
+           (attributes  (org-export-read-attribute :attr_html src-block))
+           ;; this was an idea to collect attributes -- doesn't seem to make sense.  
+           ;; (extra-atts (if klipsify
+           ;;                 ;; (cl-loop for (key  value) in attributes
+           ;;                 ;;          collect (format "%s=\"%s\"" key value))
+           ;;                 ;; (message "oops not klipsify")
+           ;;                 ""
+           ;;               ""))
+               )
+      ;; debugging messages, no longer necessary
+      ;; (message "html attributes=%s" attributes)
+      ;; (message "html code attribsis a %s" (stringp (org-export-read-attribute :attr_html src-block :class)))
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")
                   label
                   code)
-        (cond ((eq lang "javascript ")))
-        (format
-         "<div %sclass=\"org-src-container\">\n%s%s\n</div>%s"
-         (if klipsify "style=\"display:none;\" " "")
-         (if (not caption) ""
-           (format "<label class=\"org-src-name\">%s</label>"
-                   (org-export-data caption info)))
-         (if use-highlight
-             (format "\n<pre%s%s><code class=\"%s\" %s>%s</code></pre>"
-                     (or (frag-class frag info) "")
-                     label lang code-attribs code)
-           (format "\n<pre %s%s>%s</pre>"
-                   (or (frag-class frag info)
-                       (format " class=\"src src-%s\"" lang))
-                   label code)
-           )
-         ;; (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
-         ;;                      lang code) "")
-         (if klipsify (concat  "<iframe height=\"500px\" width= \"100%\" srcdoc='
-<pre><code class= \"klipse\">
-" code  "
+        (if klipsify
+            (concat
+             "<iframe style=\"background-color:white;\" height=\"500px\" width= \"100%\" srcdoc='<html><body><pre><code "
+             (if (string= lang "html" )"data-editor-type=\"html\"  "  "") "class=\"klipse\" "code-attribs ">
+" (if (string= lang "html")
+      (replace-regexp-in-string "'" "&#39;"
+                                (replace-regexp-in-string "&" "&amp;"
+                                                          (replace-regexp-in-string "<" "&lt;"
+                                                                                    (replace-regexp-in-string ">" "&gt;"
+                                                                                                              (cl-letf (((symbol-function 'org-html-htmlize-region-for-paste)
+                                                                                                                         #'buffer-substring))
+                                                                                                                (org-html-format-code src-block info))))))
+    (replace-regexp-in-string "'" "&#39;"
+                              code))  "
 </code></pre>
 <link rel= \"stylesheet\" type= \"text/css\" href=\"" org-reveal-klipse-css "\">
 <style>
@@ -1054,9 +1061,23 @@ contextual information."
 <script>
 window.klipse_settings = { " langselector  ": \".klipse\" };
 </script>
-<script src= \"" org-reveal-klipse-js "\"></script>
+<script src= \"" org-reveal-klipse-js "\"></script></body></html>
 '>
-</iframe>") "") )))))
+</iframe>")
+          (format
+            "<div class=\"org-src-container\">\n%s%s\n</div>"
+            (if (not caption) ""
+              (format "<label class=\"org-src-name\">%s</label>"
+                      (org-export-data caption info)))
+            (if use-highlight
+                (format "\n<pre%s%s><code class=\"%s\" %s>%s</code></pre>"
+                        (or (frag-class frag info) "")
+                        label lang code-attribs code)
+              (format "\n<pre %s%s>%s</pre>"
+                      (or (frag-class frag info)
+                          (format " class=\"src src-%s\"" lang))
+                      label code)
+              )))))))
 
 (defun org-reveal-quote-block (quote-block contents info)
   "Transcode a QUOTE-BLOCK element from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -994,14 +994,19 @@ contextual information."
 			 :attr_reveal src-block :code_attribs) ""))
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
-                      (format " id=\"%s\"" lbl)))))
+                      (format " id=\"%s\"" lbl))))
+           (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
+                           (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
+           ;;(klipse-hidden (if (assoc 'klipse org-reveal-external-plugins) " style=\"display:hidden;\"") nil)
+                      )
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")
                   label
                   code)
         (format
-         "<div class=\"org-src-container\">\n%s%s\n</div>"
+         "<div %sclass=\"org-src-container\">\n%s%s\n</div>%s"
+         (if klipsify "style=\"display:none;\" " "")
          (if (not caption) ""
            (format "<label class=\"org-src-name\">%s</label>"
                    (org-export-data caption info)))
@@ -1012,7 +1017,10 @@ contextual information."
            (format "\n<pre %s%s>%s</pre>"
                    (or (frag-class frag info)
                        (format " class=\"src src-%s\"" lang))
-                   label code)))))))
+                   label code)
+           )
+         (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
+                              lang code) ""))))))
 
 (defun org-reveal-quote-block (quote-block contents info)
   "Transcode a QUOTE-BLOCK element from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -335,13 +335,13 @@ content."
           (const multiplex)))
 
 (defcustom org-reveal-external-plugins nil
-  "Additional third-party Plugins to load with reveal. Each entry
-  should contain a name and an expression of the form 
-  \"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
-  Note that some plugins have dependencies such as jquery; these must be included here as well, 
-  BEFORE the plugins that depend on them."
+  "Additional third-party Plugins to load with reveal. 
+Each entry should contain a name and an expression of the form 
+\"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
+Note that some plugins have dependencies such as jquery; these must be included here as well, 
+BEFORE the plugins that depend on them."
   :group 'org-rexport-reveal
-  :type 'plist)
+  :type 'alist)
 
 (defcustom org-reveal-single-file nil
   "Export presentation into one single HTML file, which embedded
@@ -729,10 +729,14 @@ dependencies: [
                                          (wrong-type-argument nil))))
                    (or (and buffer-plugins (listp buffer-plugins) buffer-plugins)
                        org-reveal-plugins))))
+               (external-plugins
+                (cl-loop for (key . value) in org-reveal-external-plugins
+                         collect (format  value root-path )) )
+               (all-plugins (if external-plugins (append external-plugins builtin-codes) builtin-codes))
                (extra-codes (plist-get info :reveal-extra-js))
                (total-codes
-                (if (string= "" extra-codes) builtin-codes
-                  (append (list extra-codes) builtin-codes))))
+                (if (string= "" extra-codes) all-plugins (append (list extra-codes) all-plugins))                ))
+          (message "external-plugins= %s" external-plugins)
           (mapconcat 'identity total-codes ",\n"))
         "]\n"
          ))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -994,9 +994,6 @@ holding contextual information."
   "Transcode a SRC-BLOCK element from Org to Reveal.
 CONTENTS holds the contents of the item.  INFO is a plist holding
 contextual information."
-  (message  "%s" (plist-get (cadr src-block) :attr_html))
-  (if (org-export-read-attribute :attr_html src-block :data-library)
-      (message "could do something useful here with the data-library element"))
   (if (org-export-read-attribute :attr_html src-block :textarea)
       (org-html--textarea-block src-block)
     (let* ((use-highlight (org-reveal--using-highlight.js info))
@@ -1022,18 +1019,7 @@ contextual information."
                                ((string= lang "ruby") "selector_eval_ruby")
                                ((string= lang "html") "selector_eval_html"))
                          )
-           (attributes  (org-export-read-attribute :attr_html src-block))
-           ;; this was an idea to collect attributes -- doesn't seem to make sense.  
-           ;; (extra-atts (if klipsify
-           ;;                 ;; (cl-loop for (key  value) in attributes
-           ;;                 ;;          collect (format "%s=\"%s\"" key value))
-           ;;                 ;; (message "oops not klipsify")
-           ;;                 ""
-           ;;               ""))
-               )
-      ;; debugging messages, no longer necessary
-      ;; (message "html attributes=%s" attributes)
-      ;; (message "html code attribsis a %s" (stringp (org-export-read-attribute :attr_html src-block :class)))
+)
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -334,6 +334,15 @@ content."
           (const remotes)
           (const multiplex)))
 
+(defcustom org-reveal-external-plugins nil
+  "Additional third-party Plugins to load with reveal. Each entry
+  should contain a name and an expression of the form 
+  \"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
+  Note that some plugins have dependencies such as jquery; these must be included here as well, 
+  BEFORE the plugins that depend on them."
+  :group 'org-rexport-reveal
+  :type 'plist)
+
 (defcustom org-reveal-single-file nil
   "Export presentation into one single HTML file, which embedded
   JS scripts and pictures."


### PR DESCRIPTION
the [klipse](https://github.com/viebel/klipse) library allows live execution of javascript, clojure, ruby, python, and scheme code snippets in an html webpage.  This seems like an important use case for users of org-reveal, so I've made some changes to org-reveal that support the use of this library in exported presentations.  

It involves some ad-hoc changes to org-reveal-src-block, so I am not positive that this is the best way to accomplish this; but it seems better than nothing.  

I would love to hear your comments.  Thanks!

PS, this builds on the changes in #256.