### PR TITLE
Mention how to disable TOC in README tips

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -703,6 +703,16 @@ Store the names and loading instructions for each plugin in the defcustom ~org-r
 ,#+OPTIONS: num:nil
 #+END_SRC
 
+** Disable Table of Contents
+
+   Add =toc:nil= to =#+OPTIONS=
+#+BEGIN_SRC org
+,#+OPTIONS: toc:nil
+#+END_SRC
+
+   This is actually an option recognized by =org-export=. It is only mentioned
+   here because slide decks often do not need a TOC.
+
 ** Internal Links
 
    Reveal.js supports only jump between slides, but not between


### PR DESCRIPTION
The table of contents is not always needed and it gets cramped even for small heading trees, see issue #261. This change just mentions in the README how you can disable the table generation.