### PR TITLE
Enhance support for generated slides, new support for audio fragments

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -502,12 +502,14 @@ suitable audio files to the current directory first.)
     - =#+OPTIONS= tags:\\
       =reveal_control=, =reveal_progress=, =reveal_history=,
       =reveal_center=, =reveal_rolling_links=, =reveal_keyboard=,
-      =reveal_mousewheel=, =reveal_overview=
+      =reveal_mousewheel=, =reveal_overview=,
+      =reveal_inter_presentation_links=
     - Custom variables:\\
       =org-reveal-control=, =org-reveal-progress=,
       =org-reveal-history=, =org-reveal-center=,
       =org-reveal-rolling-links=, =org-reveal-keyboard=,
-      =org-reveal-mousewheel=, =org-reveal-overview=
+      =org-reveal-mousewheel=, =org-reveal-overview=,
+      =reveal_inter_presentation_links=
 
     For an example, please refer to the heading part of this document.
 
@@ -753,6 +755,10 @@ Store the names and loading instructions for each plugin in the defcustom ~org-r
 
    * [[Tips]].
    * [[#my-heading][Heading]] with a =CUSTOM_ID= property.
+
+   If you add =reveal_inter_presentation_links:t= to =#+OPTIONS=, such
+   links also work between presentations on the same server, e.g.,
+   =[[file:somefile.org::#anchor][link text]]=.
 
 ** Custom JS
 

--- a/Readme.org
+++ b/Readme.org
@@ -501,10 +501,13 @@ suitable audio files to the current directory first.)
 
     - =#+OPTIONS= tags:\\
       =reveal_control=, =reveal_progress=, =reveal_history=,
-      =reveal_center=, =reveal_rolling_links=, =reveal_keyboard=, =reveal_overview=
+      =reveal_center=, =reveal_rolling_links=, =reveal_keyboard=,
+      =reveal_mousewheel=, =reveal_overview=
     - Custom variables:\\
       =org-reveal-control=, =org-reveal-progress=,
-      =org-reveal-history=, =org-reveal-center=, =org-reveal-rolling-links=, =org-reveal-keyboard=, =org-reveal-overview=
+      =org-reveal-history=, =org-reveal-center=,
+      =org-reveal-rolling-links=, =org-reveal-keyboard=,
+      =org-reveal-mousewheel=, =org-reveal-overview=
 
     For an example, please refer to the heading part of this document.
 

--- a/Readme.org
+++ b/Readme.org
@@ -1,3 +1,4 @@
+# Local IspellDict: en
 #+Title: Introduction to Org-Reveal
 #+Author: Yujie Wen
 #+Email: yjwen.ty@gmail.com
@@ -17,8 +18,25 @@
 #+REVEAL_PLUGINS: (markdown notes)
 #+REVEAL_EXTRA_CSS: ./local.css
 
-[[http://melpa.org/#/ox-reveal][file:http://melpa.org/packages/ox-reveal-badge.svg]]
 [[http://www.gnu.org/licenses/gpl-3.0.html][http://img.shields.io/:license-gpl3-blue.svg]]
+
+*Note*: This fork of Org-Reveal is /not/ available on MELPA.  Thus,
+contrary to the installation instructions below (which I keep here in
+the hope that Org-Reveal will be maintained again), you need to clone my
+repository:
+#+BEGIN_SRC sh
+git clone https://github.com/lechten/org-reveal.git
+#+END_SRC
+
+Actually, if you are interested in my version, I suggest that you take
+a look at [[https://gitlab.com/oer/emacs-reveal][emacs-reveal]], which
+embeds this repository, reveal.js, and useful plugins as submodules,
+combined with suitable Emacs configuration.
+A [[https://gitlab.com/oer/emacs-reveal-howto][Howto for the generation of reveal.js presentations (slides with audio) with emacs-reveal]]
+exists as well.
+
+I use emacs-reveal to generate Open Educational Resources (OER):
+[[https://oer.gitlab.io/OS/][OER presentations for a course on operating systems]]
 
 * Reveal.js and Org-Reveal
 

--- a/Readme.org
+++ b/Readme.org
@@ -803,7 +803,7 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    custom-id, as the examples below:
 
    * [[Tips]].
-   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.
+   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.q
 
    If you add =reveal_inter_presentation_links:t= to =#+OPTIONS=, such
    links also work between presentations on the same server, e.g.,
@@ -827,6 +827,25 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    ~#+REVEAL_INIT_SCRIPT~ (multiple statements are concatenated) or by
    custom variable ~org-reveal-init-script~.
 
+** Executable Source Blocks
+To allow live execution of code in some languages, enable the klipsify plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
+
+*** HTML Src Block
+#+BEGIN_SRC html
+<h1 class="whatever">hello, what's your name</h1>
+#+END_SRC
+
+*** Javascript Src Block
+#+BEGIN_SRC js
+console.log("success");
+var x='string using single quote';
+x
+#+END_SRC
+
+*** Perl Src Block (not klipsified)
+#+BEGIN_SRC perl
+I don't know perl!
+#+END_SRC
 * Thanks
 
   Courtesy to:

--- a/Readme.org
+++ b/Readme.org
@@ -534,9 +534,16 @@ suitable audio files to the current directory first.)
     For an example, please refer to the heading part of this document.
 
 ** Third-Party Plugins
-Reveal.js is also extensible through third-party plugins. Org-reveal now includes a mechanism to load these as well. It's a little more complicated, because we need to store the specific javascript loading code in a defcustom.
+Reveal.js is also extensible through third-party plugins, which can be loaded with Org-Reveal. The paths to javascript loading code need to be customized in the variable ~org-reveal-external-plugins~. This variable can be an associative list or a file. If it is an associative list the first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form: ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}"~
+If you need the async or callback parameters, include those too.
 
-Store the names and loading instructions for each plugin in the defcustom ~org-reveal-external-plugins~. This defcustom is an associative list. The first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}'.  If you need the async or callback parameters, include those too.  Ox-reveal will add the plugin to the dependencies parameter when Reveal is initialized.
+#+REVEAL: split
+
+If ~org-reveal-external-plugins~ is a filename, that file must contain strings of the above format, one per line (without names of plugins, just the ~src~ information embedded in braces); this can also be configured within your org presentation with a line like this:
+
+=#+REVEAL_EXTERNAL_PLUGINS: external_plugins.js=
+
+In any case, Org-Reveal will add the plugins to the dependencies parameter when Reveal is initialized.
 
 ** Highlight Source Code
 

--- a/Readme.org
+++ b/Readme.org
@@ -443,7 +443,7 @@
    * I appear.
 
 
-** Data State
+** Data State and Class for TOC slide
    :PROPERTIES:
    :reveal_data_state: alert
    :END:
@@ -452,6 +452,16 @@
    display style, as illustrated above.
 
    Available data states are: alert|blackout|soothe.
+
+   To add a ~data-state~ attribute to a generated title slide or
+   table of contents slide, you can use the following options:
+
+   * =REVEAL_TITLE_SLIDE_STATE=
+   * =REVEAL_TOC_SLIDE_STATE=
+
+   To add a ~class~ attribute to a generated table of contents slide,
+   you can use the option =REVEAL_TOC_SLIDE_CLASS=.
+
 
 ** Plug-ins
 

--- a/Readme.org
+++ b/Readme.org
@@ -740,7 +740,7 @@ In any case, Org-Reveal will add the plugins to the dependencies parameter when 
 
 ** Export into Single File
 
-   By setting option =reveal_single_file= to ~t~, images and necessary
+   By setting option =reveal_single_file= to ~t~, images and basic
    Reveal.js scripts will be embedded into the exported HTML file, to make
    a portable HTML. Please note that remote images will /not/ be included in the
    single file, so presentations with remote images will still require an Internet
@@ -752,12 +752,22 @@ In any case, Org-Reveal will add the plugins to the dependencies parameter when 
    ,#+OPTIONS: reveal_single_file:t
    #+END_SRC
 
-   When exporting into single file, functions provided by Reveal.js
-   libraries will be disabled due to limitation, including PDF export,
-   Markdown support, zooming, speaker notes and remote control.
+#+REVEAL: split
 
-   Code highlight by highlight.js is also disabled. But *code
-   highlight by Emacs is not effected.*
+   *Limitations* of single file export
+   * Some functions provided by Reveal.js libraries will be
+     *disabled*, including PDF export, Markdown support, zooming,
+     speaker notes, and remote control.
+     * Code highlighting by highlight.js is also disabled, but *code
+       highlighting by Emacs is not affected.*
+   * Plugins are *not* enabled.
+   * CSS needs to be *self-contained*.  Neither ~@import~ rules nor
+     other forms of URLs work (images need to be embedded as
+     data URIs).
+   * If you use ~org-reveal-title-slide~ with custom HTML code and
+     images, you need to embed images in the form of data URIs
+     yourself.
+
 
 ** Export Current Subtree
 

--- a/Readme.org
+++ b/Readme.org
@@ -584,6 +584,13 @@ In any case, Org-Reveal will add the plugins to the dependencies parameter when 
     The "%r" in the given CSS file name will be replaced by Reveal.js'
     URL.
 
+** Editable Source Code
+It is now possible to embed code blocks in a codemirror instance in order to edit code during a presentation.  At present, this capacity is turned on or off at time export using these defcustoms:
+- ~org-reveal-klipsify-src~
+- ~org-reveal-klipse-css~
+- ~org-reveal-klipse-js~
+TThis feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present couce editing is supported in javacript, clojure, php, ruby, scheme, and pyhton only.  
+
 ** MathJax
   :PROPERTIES:
   :CUSTOM_ID: my-heading

--- a/Readme.org
+++ b/Readme.org
@@ -589,7 +589,7 @@ It is now possible to embed code blocks in a codemirror instance in order to edi
 - ~org-reveal-klipsify-src~
 - ~org-reveal-klipse-css~
 - ~org-reveal-klipse-js~
-TThis feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present couce editing is supported in javacript, clojure, php, ruby, scheme, and pyhton only.  
+This feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present code editing is supported in javacript, clojure, php, ruby, scheme, and python only.  
 
 ** MathJax
   :PROPERTIES:
@@ -803,7 +803,7 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    custom-id, as the examples below:
 
    * [[Tips]].
-   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.q
+   * [[#my-heading][Heading]] with a =CUSTOM_ID= property.
 
    If you add =reveal_inter_presentation_links:t= to =#+OPTIONS=, such
    links also work between presentations on the same server, e.g.,
@@ -828,7 +828,7 @@ TThis feature is turned off by default and needs to be switched on with ~org-rev
    custom variable ~org-reveal-init-script~.
 
 ** Executable Source Blocks
-To allow live execution of code in some languages, enable the klipsify plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
+To allow live execution of code in some languages, enable the klipse plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
 
 *** HTML Src Block
 #+BEGIN_SRC html

--- a/Readme.org
+++ b/Readme.org
@@ -22,17 +22,15 @@
 
 * Note
 
-This fork of Org-Reveal is /not/ available on MELPA.  Thus,
-contrary to the installation instructions below (which I keep here in
-the hope that Org-Reveal will be maintained again), you need to clone my
-repository:
-#+BEGIN_SRC sh
-git clone https://github.com/lechten/org-reveal.git
-#+END_SRC
+As of February 2019, this fork of Org-Reveal is /not/ maintained any longer.
+Please check out
+[[https://gitlab.com/oer/org-re-reveal][org-re-reveal]],
+which continues my work and which has been accepted into
+[[https://melpa.org/#/org-re-reveal][MELPA]].
 
 Actually, if you are interested in my version, I suggest that you take
 a look at [[https://gitlab.com/oer/emacs-reveal][emacs-reveal]], which
-embeds this repository, reveal.js, and useful plugins as submodules,
+embeds my fork, reveal.js, and useful plugins as submodules,
 combined with suitable Emacs configuration.
 A [[https://gitlab.com/oer/emacs-reveal-howto][Howto for the generation of reveal.js presentations (slides with audio) with emacs-reveal]]
 exists as well.

--- a/Readme.org
+++ b/Readme.org
@@ -251,12 +251,14 @@ I use emacs-reveal to generate Open Educational Resources (OER):
     To customize the title slide, please set ~org-reveal-title-slide~
     to a string of HTML markups. The following escape sequences can
     be used to retrieve document information:
-    | ~%t~ | Title     |
-    | ~%s~ | Subtitle  |
-    | ~%a~ | Author    |
-    | ~%e~ | Email     |
-    | ~%d~ | Date      |
-    | ~%%~ | Literal % |
+    | ~%t~ | Title            |
+    | ~%s~ | Subtitle         |
+    | ~%a~ | Author           |
+    | ~%A~ | Academic title   |
+    | ~%e~ | Email            |
+    | ~%d~ | Date             |
+    | ~%m~ | Misc information |
+    | ~%%~ | Literal %        |
 
 #+REVEAL: split
     Alternatively, you can also write the title slide's HTML code
@@ -799,6 +801,18 @@ In any case, Org-Reveal will add the plugins to the dependencies parameter when 
    If you add =reveal_inter_presentation_links:t= to =#+OPTIONS=, such
    links also work between presentations on the same server, e.g.,
    =[[file:somefile.org::#anchor][link text]]=.
+
+   Reveal.js [[https://github.com/hakimel/reveal.js#internal-links][advertises]]
+   to use broken internal links, which are used in Org-Reveal by
+   default.  (Those links work with reveal.js, but are not understood
+   by search engines.)  If you change ~org-reveal--href-fragment-prefix~
+   from its default to the value of ~org-reveal--slide-id-prefix~,
+   valid links are generated:
+   #+BEGIN_SRC lisp
+   (setq org-reveal--href-fragment-prefix org-reveal--slide-id-prefix)
+   #+END_SRC
+   Whether this change is a good idea might be discussed under this
+   [[https://github.com/hakimel/reveal.js/issues/2276][reveal.js issue]].
 
 ** Custom JS
 

--- a/Readme.org
+++ b/Readme.org
@@ -238,6 +238,7 @@
     | ~%d~ | Date      |
     | ~%%~ | Literal % |
 
+#+REVEAL: split
     Alternatively, you can also write the title slide's HTML code
     (containing the above escape sequences) into a separate file and
     set ~org-reveal-title-slide~ to the name of that file.
@@ -442,6 +443,26 @@
    * I appear.
    * I appear.
 
+*** List Fragments with Audio
+
+You can also use Org-Reveal in combination with the audio-slideshow
+plugin of [[https://github.com/rajgoel/reveal.js-plugins][reveal.js-plugins]].  For example, when the audio-slideshow
+plugin is configured properly, the following plays
+~1.ogg~ when the first list item appears, ~2.ogg~ for the
+second list item, and no audio for the third.  (You need to add
+suitable audio files to the current directory first.)
+
+#+BEGIN_SRC org
+,#+ATTR_REVEAL: :frag (appear) :audio (1.ogg 2.ogg none)
+   * I appear with audio 1.ogg.
+   * I appear with audio 2.ogg.
+   * I appear without audio.
+#+END_SRC
+
+#+ATTR_REVEAL: :frag (appear) :audio (1.ogg 2.ogg none)
+   * I appear with audio 1.ogg.
+   * I appear with audio 2.ogg.
+   * I appear without audio.
 
 ** Data State and Class for TOC slide
    :PROPERTIES:

--- a/Readme.org
+++ b/Readme.org
@@ -366,7 +366,8 @@ I use emacs-reveal to generate Open Educational Resources (OER):
    By default header/footer content will only display on content
    slides. To show them also on the title and toc slide you can add
    ~reveal_global_header:t~ and ~reveal_global_footer:t~ to
-   ~#+OPTIONS:~ line.
+   ~#+OPTIONS:~ line. To show the footer on the toc slide but not on
+   the title slide, use option ~reveal_toc_footer:t~.
 
 ** Fragmented Contents
 

--- a/Readme.org
+++ b/Readme.org
@@ -20,7 +20,9 @@
 
 [[http://www.gnu.org/licenses/gpl-3.0.html][http://img.shields.io/:license-gpl3-blue.svg]]
 
-*Note*: This fork of Org-Reveal is /not/ available on MELPA.  Thus,
+* Note
+
+This fork of Org-Reveal is /not/ available on MELPA.  Thus,
 contrary to the installation instructions below (which I keep here in
 the hope that Org-Reveal will be maintained again), you need to clone my
 repository:

--- a/Readme.org
+++ b/Readme.org
@@ -793,6 +793,16 @@ This feature is turned off by default and needs to be switched on with ~org-reve
 ,#+OPTIONS: num:nil
 #+END_SRC
 
+** Disable Table of Contents
+
+   Add =toc:nil= to =#+OPTIONS=
+#+BEGIN_SRC org
+,#+OPTIONS: toc:nil
+#+END_SRC
+
+   This is actually an option recognized by =org-export=. It is only mentioned
+   here because slide decks often do not need a TOC.
+
 ** Internal Links
 
    Reveal.js supports only jump between slides, but not between

--- a/Readme.org
+++ b/Readme.org
@@ -522,14 +522,14 @@ suitable audio files to the current directory first.)
     - =#+OPTIONS= tags:\\
       =reveal_control=, =reveal_progress=, =reveal_history=,
       =reveal_center=, =reveal_rolling_links=, =reveal_keyboard=,
-      =reveal_mousewheel=, =reveal_overview=,
+      =reveal_mousewheel=, =reveal_defaulttiming=, =reveal_overview=,
       =reveal_inter_presentation_links=
     - Custom variables:\\
       =org-reveal-control=, =org-reveal-progress=,
       =org-reveal-history=, =org-reveal-center=,
       =org-reveal-rolling-links=, =org-reveal-keyboard=,
-      =org-reveal-mousewheel=, =org-reveal-overview=,
-      =reveal_inter_presentation_links=
+      =org-reveal-mousewheel=, =org-reveal-defaulttiming=,
+      =org-reveal-overview=, =reveal_inter_presentation_links=
 
     For an example, please refer to the heading part of this document.
 

--- a/Readme.org
+++ b/Readme.org
@@ -229,13 +229,18 @@
 *** Customize the Title Slide
 
     To customize the title slide, please set ~org-reveal-title-slide~
-    to a string of HTML markups. The following escaping character can
+    to a string of HTML markups. The following escape sequences can
     be used to retrieve document information:
     | ~%t~ | Title     |
+    | ~%s~ | Subtitle  |
     | ~%a~ | Author    |
     | ~%e~ | Email     |
     | ~%d~ | Date      |
     | ~%%~ | Literal % |
+
+    Alternatively, you can also write the title slide's HTML code
+    (containing the above escape sequences) into a separate file and
+    set ~org-reveal-title-slide~ to the name of that file.
 
 ** Set Slide Background
 
@@ -475,7 +480,7 @@
 ** Third-Party Plugins
 Reveal.js is also extensible through third-party plugins. Org-reveal now includes a mechanism to load these as well. It's a little more complicated, because we need to store the specific javascript loading code in a defcustom.
 
-Store the names and loading instructions for each plugin in the defcustom ~org-reveal-external-plugins~. This defcustom is an associative list. The first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}'.  If you need the async or callback parameters, include those too.  Ox-reveal will add the plugin to the dependencies parameter when Reveal is initialized.  
+Store the names and loading instructions for each plugin in the defcustom ~org-reveal-external-plugins~. This defcustom is an associative list. The first element of each Assoc cell is a symbol -- the name of the plugin -- and the second is a string that will be expanded by the ~format~ function when the plugin is loaded. So, this second element should have the form ~" {src: \"%srelative/path/toplugin/from/reveal/root.js\"}'.  If you need the async or callback parameters, include those too.  Ox-reveal will add the plugin to the dependencies parameter when Reveal is initialized.
 
 ** Highlight Source Code
 

--- a/Readme.org
+++ b/Readme.org
@@ -524,12 +524,14 @@ suitable audio files to the current directory first.)
       =reveal_control=, =reveal_progress=, =reveal_history=,
       =reveal_center=, =reveal_rolling_links=, =reveal_keyboard=,
       =reveal_mousewheel=, =reveal_defaulttiming=, =reveal_overview=,
+      =reveal_fragmentinurl=, =reveal_pdfseparatefragments=,
       =reveal_inter_presentation_links=
     - Custom variables:\\
       =org-reveal-control=, =org-reveal-progress=,
       =org-reveal-history=, =org-reveal-center=,
       =org-reveal-rolling-links=, =org-reveal-keyboard=,
       =org-reveal-mousewheel=, =org-reveal-defaulttiming=,
+      =org-reveal-fragmentinurl=, =org-reveal-pdfseparatefragments=,
       =org-reveal-overview=, =reveal_inter_presentation_links=
 
     For an example, please refer to the heading part of this document.

--- a/Readme.org
+++ b/Readme.org
@@ -487,15 +487,18 @@ suitable audio files to the current directory first.)
    * I appear with audio 2.ogg.
    * I appear without audio.
 
-** Data State and Class for TOC slide
+** Data State and Classes for Headlines and Slides, including generated ones
    :PROPERTIES:
    :reveal_data_state: alert
    :END:
 
-   Set property =reveal_data_state= to headings to change this slide's
-   display style, as illustrated above.
-
-   Available data states are: alert|blackout|soothe.
+   Set property =reveal_data_state= to a headline to change this
+   slide's display style.  (In the past, ~reveal.min.css~ defined
+   classes ~alert~, ~blackout~, ~soothe~, which were activated by the
+   data state.)  In any case, property =reveal_data_state= adds a
+   ~data-state~ attribute to the slide's ~section~ element, which is
+   called “Slide State” by reveal.js; this might also be useful with
+   reveal.js plugins.
 
    To add a ~data-state~ attribute to a generated title slide or
    table of contents slide, you can use the following options:
@@ -503,8 +506,12 @@ suitable audio files to the current directory first.)
    * =REVEAL_TITLE_SLIDE_STATE=
    * =REVEAL_TOC_SLIDE_STATE=
 
-   To add a ~class~ attribute to a generated table of contents slide,
-   you can use the option =REVEAL_TOC_SLIDE_CLASS=.
+   To add a ~class~ attribute to the ~section~ element of a generated
+   table of contents slide, you can use the option
+   =REVEAL_TOC_SLIDE_CLASS=.
+
+   To add a ~class~ attribute to a slide's ~h~-element, add property
+   =html_headline_class= to the headline.
 
 
 ** Plug-ins
@@ -589,7 +596,7 @@ It is now possible to embed code blocks in a codemirror instance in order to edi
 - ~org-reveal-klipsify-src~
 - ~org-reveal-klipse-css~
 - ~org-reveal-klipse-js~
-This feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present code editing is supported in javacript, clojure, php, ruby, scheme, and python only.  
+This feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present code editing is supported in javacript, clojure, php, ruby, scheme, and python only.
 
 ** MathJax
   :PROPERTIES:
@@ -838,7 +845,7 @@ This feature is turned off by default and needs to be switched on with ~org-reve
    custom variable ~org-reveal-init-script~.
 
 ** Executable Source Blocks
-To allow live execution of code in some languages, enable the klipse plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
+To allow live execution of code in some languages, enable the klipse plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.
 
 *** HTML Src Block
 #+BEGIN_SRC html

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -948,8 +948,9 @@ the result is the Data URIs of the referenced image."
         (org-reveal--format-image-data-uri link clean-path info)
       (if want-embed-image
           (error "Cannot embed image %s" raw-path)
-        (replace-regexp-in-string "<a href=\"#" "<a href=\"#/slide-"
-                                  (org-html-link link desc info))))))
+        (replace-regexp-in-string
+	 "<a href=\"\\([^#]*\\)#" "<a href=\"\\1#/slide-"
+         (org-html-link link desc info))))))
 
 (defun org-reveal-latex-environment (latex-env contents info)
   "Transcode a LaTeX environment from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -50,6 +50,7 @@
     (:reveal-rolling-links nil "reveal_rolling_links" org-reveal-rolling-links t)
     (:reveal-slide-number nil "reveal_slide_number" org-reveal-slide-number t)
     (:reveal-keyboard nil "reveal_keyboard" org-reveal-keyboard t)
+    (:reveal-mousewheel nil "reveal_mousewheel" org-reveal-mousewheel t)
     (:reveal-overview nil "reveal_overview" org-reveal-overview t)
     (:reveal-width nil "reveal_width" org-reveal-width t)
     (:reveal-height nil "reveal_height" org-reveal-height)
@@ -237,6 +238,11 @@ slide, where the following escaping elements are allowed:
   :type 'string)
 
 (defcustom org-reveal-keyboard t
+  "Reveal use keyboard navigation."
+  :group 'org-export-reveal
+  :type 'boolean)
+
+(defcustom org-reveal-mousewheel nil
   "Reveal use keyboard navigation."
   :group 'org-export-reveal
   :type 'boolean)
@@ -648,6 +654,7 @@ center: %s,
 slideNumber: %s,
 rollingLinks: %s,
 keyboard: %s,
+mouseWheel: %s,
 overview: %s,
 "
             (if (plist-get info :reveal-control) "true" "false")
@@ -659,6 +666,7 @@ overview: %s,
                 "false"))
             (if (plist-get info :reveal-rolling-links) "true" "false")
             (if (plist-get info :reveal-keyboard) "true" "false")
+            (if (plist-get info :reveal-mousewheel) "true" "false")
             (if (plist-get info :reveal-overview) "true" "false"))
 
      ;; slide width

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -67,10 +67,13 @@
     (:reveal-slide-global-header nil "reveal_global_header" org-reveal-global-header t)
     (:reveal-slide-global-footer nil "reveal_global_footer" org-reveal-global-footer t)
     (:reveal-title-slide-background "REVEAL_TITLE_SLIDE_BACKGROUND" nil nil t)
+    (:reveal-title-slide-state "REVEAL_TITLE_SLIDE_STATE" nil nil t)
     (:reveal-title-slide-background-size "REVEAL_TITLE_SLIDE_BACKGROUND_SIZE" nil nil t)
     (:reveal-title-slide-background-position "REVEAL_TITLE_SLIDE_BACKGROUND_POSITION" nil nil t)
     (:reveal-title-slide-background-repeat "REVEAL_TITLE_SLIDE_BACKGROUND_REPEAT" nil nil t)
     (:reveal-title-slide-background-transition "REVEAL_TITLE_SLIDE_BACKGROUND_TRANSITION" nil nil t)
+    (:reveal-toc-slide-state "REVEAL_TOC_SLIDE_STATE" nil nil t)
+    (:reveal-toc-slide-class "REVEAL_TOC_SLIDE_CLASS" nil nil t)
     (:reveal-default-slide-background "REVEAL_DEFAULT_SLIDE_BACKGROUND" nil nil t)
     (:reveal-default-slide-background-size "REVEAL_DEFAULT_SLIDE_BACKGROUND_SIZE" nil nil t)
     (:reveal-default-slide-background-position "REVEAL_DEFAULT_SLIDE_BACKGROUND_POSITION" nil nil t)
@@ -749,12 +752,23 @@ dependencies: [
   (let ((toc (org-html-toc depth info)))
     (when toc
       (let ((toc-slide-with-header (plist-get info :reveal-slide-global-header))
-            (toc-slide-with-footer (plist-get info :reveal-slide-global-footer)))
-        (concat "<section id=\"table-of-contents\">\n"
+            (toc-slide-with-footer (plist-get info :reveal-slide-global-footer))
+	    (toc-slide-state (plist-get info :reveal-toc-slide-state))
+	    (toc-slide-class (plist-get info :reveal-toc-slide-class))
+	    (toc (replace-regexp-in-string "<a href=\"#" "<a href=\"#/slide-" toc)))
+        (concat "<section id=\"table-of-contents\""
+		(when toc-slide-state
+		  (format " data-state=\"%s\"" toc-slide-state))
+		">\n"
                 (when toc-slide-with-header
                    (let ((header (plist-get info :reveal-slide-header)))
                      (when header (format "<div class=\"slide-header\">%s</div>\n" header))))
-                (replace-regexp-in-string "<a href=\"#" "<a href=\"#/slide-" toc)
+                (if toc-slide-class
+		    (replace-regexp-in-string
+		     "<h\\([1-3]\\)>"
+		     (format "<h\\1 class=\"%s\">" toc-slide-class)
+		     toc)
+		  toc)
                 (when toc-slide-with-footer
                    (let ((footer (plist-get info :reveal-slide-footer)))
                      (when footer (format "<div class=\"slide-footer\">%s</div>\n" footer))))
@@ -1081,6 +1095,7 @@ info is a plist holding export options."
              (title-slide-background-position (plist-get info :reveal-title-slide-background-position))
              (title-slide-background-repeat (plist-get info :reveal-title-slide-background-repeat))
              (title-slide-background-transition (plist-get info :reveal-title-slide-background-transition))
+             (title-slide-state (plist-get info :reveal-title-slide-state))
              (title-slide-with-header (plist-get info :reveal-slide-global-header))
              (title-slide-with-footer (plist-get info :reveal-slide-global-footer)))
          (concat "<section id=\"sec-title-slide\""
@@ -1094,6 +1109,8 @@ info is a plist holding export options."
                    (concat " data-background-repeat=\"" title-slide-background-repeat "\""))
                  (when title-slide-background-transition
                    (concat " data-background-transition=\"" title-slide-background-transition "\""))
+		 (when title-slide-state
+		  (concat " data-state=\"" title-slide-state "\""))
                  ">"
                  (when title-slide-with-header
                    (let ((header (plist-get info :reveal-slide-header)))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -35,7 +35,7 @@
 (require 'ox-html)
 (require 'cl-extra) ; cl-every
 (require 'cl-lib)   ; cl-mapcar
-(require 'cl-macs)  ; cl-loop, cl-letf, cl-assert
+(require 'cl-macs)  ; cl-loop, cl-letf, cl-assert, cl-case
 (require 'subr-x)   ; string-trim
 (require 'url-parse)
 
@@ -968,7 +968,7 @@ holding export options."
 Currently, only splitting of slides/sections is implemented.
 The current section is closed by FOOTER, which may be nil.
 use the previous section tag as the tag of the split section. "
-  (case (intern key)
+  (cl-case (intern key)
     (split (format "%s</section>\n%s"
 		   footer org-reveal--last-slide-section-tag))))
 
@@ -996,7 +996,7 @@ The possibly empty FOOTER is inserted at the end of the slide."
 			  (and checkbox " ")))
 	(br (org-html-close-tag "br" nil info)))
     (concat
-     (case type
+     (cl-case type
        (ordered
 	(let* ((counter term-counter-id)
 	       (extra (if counter (format " value=\"%s\"" counter) "")))
@@ -1018,7 +1018,7 @@ The possibly empty FOOTER is inserted at the end of the slide."
 		 (format "<dd%s>" attr-html)))))
      (unless (eq type 'descriptive) checkbox)
      (and contents (org-trim contents))
-     (case type
+     (cl-case type
        (ordered "</li>")
        (unordered "</li>")
        (descriptive "</dd>")))))
@@ -1051,7 +1051,7 @@ CONTENTS is nil. INFO is a plist holding contextual information."
 	 (footer (plist-get info :reveal-slide-footer))
 	 (footer-div (if footer
 		       (format org-reveal-slide-footer-html footer) "")))
-    (case (intern key)
+    (cl-case (intern key)
       (REVEAL (org-reveal-parse-keyword-value value footer-div))
       (REVEAL_HTML value)
       (HTML value)
@@ -1201,7 +1201,7 @@ CONTENTS is the contents of the list. INFO is a plist holding
 contextual information.
 
 Extract and set `attr_html' to plain-list tag attributes."
-  (let ((tag (case (org-element-property :type plain-list)
+  (let ((tag (cl-case (org-element-property :type plain-list)
                (ordered "ol")
                (unordered "ul")
                (descriptive "dl")))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -159,7 +159,10 @@ slide, where the following escaping elements are allowed:
   %a stands for the author's name.
   %e stands for the author's email.
   %d stands for the date.
-  %% stands for a literal %."
+  %% stands for a literal %.
+
+Alternatively, the string can also be the name of a file with the title
+slide's HTML code (containing the above escape sequences)."
   :group 'org-export-reveal
   :type '(choice (const :tag "No title slide" nil)
                  (const :tag "Auto title slide" 'auto)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -71,6 +71,7 @@
     (:reveal-slide-global-footer nil "reveal_global_footer" org-reveal-global-footer t)
     (:reveal-title-slide-background "REVEAL_TITLE_SLIDE_BACKGROUND" nil nil t)
     (:reveal-title-slide-state "REVEAL_TITLE_SLIDE_STATE" nil nil t)
+    (:reveal-title-slide-timing "REVEAL_TITLE_SLIDE_TIMING" nil nil t)
     (:reveal-title-slide-background-size "REVEAL_TITLE_SLIDE_BACKGROUND_SIZE" nil nil t)
     (:reveal-title-slide-background-position "REVEAL_TITLE_SLIDE_BACKGROUND_POSITION" nil nil t)
     (:reveal-title-slide-background-repeat "REVEAL_TITLE_SLIDE_BACKGROUND_REPEAT" nil nil t)
@@ -1195,6 +1196,7 @@ info is a plist holding export options."
              (title-slide-background-repeat (plist-get info :reveal-title-slide-background-repeat))
              (title-slide-background-transition (plist-get info :reveal-title-slide-background-transition))
              (title-slide-state (plist-get info :reveal-title-slide-state))
+             (title-slide-timing (plist-get info :reveal-title-slide-timing))
              (title-slide-with-header (plist-get info :reveal-slide-global-header))
              (title-slide-with-footer (plist-get info :reveal-slide-global-footer)))
          (concat "<section id=\"sec-title-slide\""
@@ -1210,6 +1212,8 @@ info is a plist holding export options."
                    (concat " data-background-transition=\"" title-slide-background-transition "\""))
 		 (when title-slide-state
 		  (concat " data-state=\"" title-slide-state "\""))
+		 (when title-slide-timing
+		  (concat " data-timing=\"" title-slide-timing "\""))
                  ">"
                  (when title-slide-with-header
                    (let ((header (plist-get info :reveal-slide-header)))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1261,7 +1261,7 @@ info is a plist holding export options."
            (if-format " lang=\"%s\"" (plist-get info :language)))
    "<meta charset=\"utf-8\"/>\n"
    (if-format "<title>%s</title>\n" (org-export-data (plist-get info :title) info))
-   (if-format "<meta name=\"author\" content=\"%s\"/>\n" (plist-get info :author))
+   (if-format "<meta name=\"author\" content=\"%s\"/>\n" (org-element-interpret-data (plist-get info :author)))
    (if-format "<meta name=\"description\" content=\"%s\"/>\n" (plist-get info :description))
    (if-format "<meta name=\"keywords\" content=\"%s\"/>\n" (plist-get info :keywords))
    (org-reveal-stylesheets info)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -246,7 +246,7 @@ slide, where the following escaping elements are allowed:
   :type 'boolean)
 
 (defcustom org-reveal-mousewheel nil
-  "Reveal use keyboard navigation."
+  "Reveal use mousewheel navigation."
   :group 'org-export-reveal
   :type 'boolean)
 

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -521,15 +521,15 @@ exporter."
       (org-html-special-block special-block contents info))))
 
 (defun org-reveal--add-class (elem value)
-  "Add VALUE as \"class\" attribute in HTML header element ELEM."
+  "Add VALUE as \"class\" attribute in HTML header element ELEM.
+Do nothing if \"class\" attribute is alredy present."
   (let ((match (string-match "^<h[1-9][^>]+>" elem)))
     (unless match (error "Element no headline: %s" elem))
     (let ((tag (match-string 0 elem)))
-      (when (string-match "class" tag)
-	(error "Element contains class already: %s" elem))
-      (replace-regexp-in-string "\\(<h[1-9][^>]+\\)>"
-				(format "\\1 class=\"%s\">" value)
-				elem))))
+      (unless (string-match "class" tag)
+	(replace-regexp-in-string "\\(<h[1-9][^>]+\\)>"
+				  (format "\\1 class=\"%s\">" value)
+				  elem)))))
 
 (defun org-reveal--fix-html-headline (headline contents info)
   "Convert HEADLINE with CONTENTS and INFO to HTML.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -67,6 +67,8 @@
     (:reveal-extra-js "REVEAL_EXTRA_JS" nil org-reveal-extra-js nil)
     (:reveal-hlevel "REVEAL_HLEVEL" nil nil t)
     (:reveal-title-slide "REVEAL_TITLE_SLIDE" nil org-reveal-title-slide t)
+    (:reveal-academic-title "REVEAL_ACADEMIC_TITLE" nil nil t)
+    (:reveal-miscinfo "REVEAL_MISCINFO" nil nil t)
     (:reveal-slide-global-header nil "reveal_global_header" org-reveal-global-header t)
     (:reveal-slide-global-footer nil "reveal_global_footer" org-reveal-global-footer t)
     (:reveal-title-slide-background "REVEAL_TITLE_SLIDE_BACKGROUND" nil nil t)
@@ -1053,10 +1055,20 @@ Extract and set `attr_html' to plain-list tag attributes."
             tag
             (if (string= org-html-checkbox-type 'html) "</form>" ""))))
 
+(defun org-reveal-format-spec (info)
+  "Return format specification with INFO.
+Formatting extends `org-html-format-spec' with elements for
+misc information and academic title."
+  (append (org-html-format-spec info)
+	  `((?A . ,(org-export-data
+		    (plist-get info :reveal-academic-title) info))
+	    (?m . ,(org-export-data
+		    (plist-get info :reveal-miscinfo) info)))))
+
 (defun org-reveal--build-pre/postamble (type info)
   "Return document preamble or postamble as a string, or nil."
   (let ((section (plist-get info (intern (format ":reveal-%s" type))))
-        (spec (org-html-format-spec info)))
+        (spec (org-reveal-format-spec info)))
     (when section
       (let ((section-contents
              (if (functionp (intern section)) (funcall (intern section) info)
@@ -1139,7 +1151,7 @@ contextual information."
 
 (defun org-reveal--auto-title-slide-template (info)
   "Generate the automatic title slide template."
-  (let* ((spec (org-html-format-spec info))
+  (let* ((spec (org-reveal-format-spec info))
          (title (org-export-data (plist-get info :title) info))
          (author (cdr (assq ?a spec)))
          (email (cdr (assq ?e spec)))
@@ -1224,7 +1236,7 @@ info is a plist holding export options."
 				(org-reveal--read-file-as-string title-slide))
 			       (title-string (or file-contents title-slide)))
 			  (format-spec title-string
-				       (org-html-format-spec info))))
+				       (org-reveal-format-spec info))))
                        ((eq title-slide 'auto) (org-reveal--auto-title-slide-template info)))
                  "\n"
                  (when title-slide-with-footer

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -464,9 +464,13 @@ included here as well, BEFORE the plugins that depend on them."
   :type 'string)
 
 (defcustom org-reveal-klipse-js "https://storage.googleapis.com/app.klipse.tech/plugin_prod/js/klipse_plugin.min.js"
-  "location of the klipse js source code."
+  "Location of the klipse js source code."
   :group 'org-export-reveal
   :type 'string)
+
+(defconst org-reveal-klipse-languages
+  '("javascript" "js" "ruby" "scheme" "clojure" "php" "html")
+  "List of languages supported by org-reveal.")
 
 (defvar org-reveal--last-slide-section-tag ""
   "Variable to cache the section tag from the last slide. ")
@@ -1278,17 +1282,18 @@ contextual information."
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
                       (format " id=\"%s\"" lbl))))
-           (klipsify  (and org-reveal-klipsify-src
-                           (member lang '("javascript" "js" "ruby" "scheme" "clojure" "php" "html"))))
-           (langselector (cond ((or (string= lang "js") (string= lang "javascript")) "selector_eval_js")
-                               ((string= lang "clojure") "selector")
-                               ((string= lang "python") "selector_eval_python_client")
-                               ((string= lang "scheme") "selector_eval_scheme")
-                               ((string= lang "ruby") "selector_eval_ruby")
-                               ((string= lang "php") "selector_eval_php")
-                               ((string= lang "html") "selector_eval_html"))
-                         )
-)
+           (klipsify (and org-reveal-klipsify-src
+                          (member lang org-reveal-klipse-languages)))
+           (langselector
+	    (cond ((or (string= lang "js") (string= lang "javascript"))
+		   "selector_eval_js")
+                  ((string= lang "clojure") "selector")
+                  ((string= lang "python") "selector_eval_python_client")
+                  ((string= lang "scheme") "selector_eval_scheme")
+                  ((string= lang "ruby") "selector_eval_ruby")
+                  ((string= lang "php") "selector_eval_php")
+                  ((string= lang "html") "selector_eval_html")
+		  )))
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1475,11 +1475,12 @@ fragment attributes."
 	    attr-html)
       (when frag-index
 	;; Index positions should be numbers or the minus sign.
-	(assert (or (integerp frag-index)
-		    (eq frag-index '-)
-		    (and (not (listp frag-index))
-			 (not (char-equal (string-to-char frag-index) ?\())))
-		nil "Index cannot be a list: %s" frag-index)
+	(cl-assert (or (integerp frag-index)
+		       (eq frag-index '-)
+		       (and (not (listp frag-index))
+			    (not (char-equal
+				  (string-to-char frag-index) ?\())))
+		   nil "Index cannot be a list: %s" frag-index)
         (push (format ":data-fragment-index %s" frag-index) attr-html))
       (when (and frag-audio (not (string= frag-audio "none")))
         (push (format ":data-audio-src %s" frag-audio) attr-html)))
@@ -1521,17 +1522,18 @@ transformed fragment attribute to ELEM's attr_html plist."
 			       (car (read-from-string frag-audio)))))
 	    ;; As we are looking at fragments in lists, we make sure
 	    ;; that other specs are lists of proper length.
-	    (assert (listp frag-index) t
-		    "Must use list for index positions, not: %s")
+	    (cl-assert (listp frag-index) t
+		       "Must use list for index positions, not: %s")
 	    (when frag-index
-	      (assert (= (length frag-index) itemno) nil
-		      "Use one index per item!  %s has %d, need %d"
-		      frag-index (length frag-index) (length items)))
-	    (assert (listp frag-audio) t "Must use list for audio files! %s")
+	      (cl-assert (= (length frag-index) itemno) nil
+			 "Use one index per item!  %s has %d, need %d"
+			 frag-index (length frag-index) (length items)))
+	    (cl-assert (listp frag-audio) t
+		       "Must use list for audio files! %s")
 	    (when frag-audio
-	      (assert (= (length frag-audio) itemno) nil
-		      "Use one audio file per item!  %s has %d, need %d"
-		      frag-audio (length frag-index) itemno))
+	      (cl-assert (= (length frag-audio) itemno) nil
+			 "Use one audio file per item!  %s has %d, need %d"
+			 frag-audio (length frag-index) itemno))
 	    (if frag-audio
 		(cl-mapcar 'org-reveal--update-attr-html
 			   items frag-list style-list frag-index frag-audio)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -441,6 +441,21 @@ included here as well, BEFORE the plugins that depend on them."
   :group 'org-export-reveal
   :type 'string)
 
+(defcustom org-reveal-klipsify-src nil
+  "Set to non-nil if you would like to make source code blocks editable in exported presentation."
+  :group 'org-export-reveal
+  :type 'boolean)
+
+(defcustom org-reveal-klipse-css "https://storage.googleapis.com/app.klipse.tech/css/codemirror.css"
+  "Location of the codemirror css file for use with klipse."
+  :group 'org-export-reveal
+  :type 'string)
+
+(defcustom org-reveal-klipse-css "https://storage.googleapis.com/app.klipse.tech/js/klipse_plugin.js"
+  "location of the klipse js source code."
+  :group 'org-export-reveal
+  :type 'string)
+
 (defvar org-reveal--last-slide-section-tag ""
   "Variable to cache the section tag from the last slide. ")
 
@@ -1190,7 +1205,7 @@ contextual information."
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
                       (format " id=\"%s\"" lbl))))
-           (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
+           (klipsify  (and  org-reveal-klipsify-src ;;(assoc 'klipse org-reveal-external-plugins)
                            (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
            (langselector (cond ((string= lang "javascript") "selector_eval_js")
                                ((string= lang "clojure") "selector")

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -52,6 +52,7 @@
     (:reveal-slide-number nil "reveal_slide_number" org-reveal-slide-number t)
     (:reveal-keyboard nil "reveal_keyboard" org-reveal-keyboard t)
     (:reveal-mousewheel nil "reveal_mousewheel" org-reveal-mousewheel t)
+    (:reveal-defaulttiming nil "reveal_defaulttiming" org-reveal-defaulttiming t)
     (:reveal-overview nil "reveal_overview" org-reveal-overview t)
     (:reveal-width nil "reveal_width" org-reveal-width t)
     (:reveal-height nil "reveal_height" org-reveal-height)
@@ -249,6 +250,11 @@ slide, where the following escaping elements are allowed:
   "Reveal use mousewheel navigation."
   :group 'org-export-reveal
   :type 'boolean)
+
+(defcustom org-reveal-defaulttiming nil
+  "Reveal use defaultTiming for speaker notes view."
+  :group 'org-export-reveal
+  :type '(choice integer (const nil)))
 
 (defcustom org-reveal-overview t
   "Reveal show overview."
@@ -691,6 +697,7 @@ slideNumber: %s,
 rollingLinks: %s,
 keyboard: %s,
 mouseWheel: %s,
+%s
 overview: %s,
 "
             (if (plist-get info :reveal-control) "true" "false")
@@ -703,6 +710,9 @@ overview: %s,
             (if (plist-get info :reveal-rolling-links) "true" "false")
             (if (plist-get info :reveal-keyboard) "true" "false")
             (if (plist-get info :reveal-mousewheel) "true" "false")
+            (let ((timing (plist-get info :reveal-defaulttiming)))
+	      (if timing (format "defaultTiming: %s," timing)
+		""))
             (if (plist-get info :reveal-overview) "true" "false"))
 
      ;; slide width

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -35,7 +35,7 @@
 (require 'ox-html)
 (require 'cl-extra) ; cl-every
 (require 'cl-lib)   ; cl-mapcar
-(require 'cl-macs)  ; cl-loop, cl-letf
+(require 'cl-macs)  ; cl-loop, cl-letf, cl-assert
 (require 'subr-x)   ; string-trim
 (require 'url-parse)
 

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1189,14 +1189,19 @@ contextual information."
 			 :attr_reveal src-block :code_attribs) ""))
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
-                      (format " id=\"%s\"" lbl)))))
+                      (format " id=\"%s\"" lbl))))
+           (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
+                           (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
+           ;;(klipse-hidden (if (assoc 'klipse org-reveal-external-plugins) " style=\"display:hidden;\"") nil)
+                      )
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")
                   label
                   code)
         (format
-         "<div class=\"org-src-container\">\n%s%s\n</div>"
+         "<div %sclass=\"org-src-container\">\n%s%s\n</div>%s"
+         (if klipsify "style=\"display:none;\" " "")
          (if (not caption) ""
            (format "<label class=\"org-src-name\">%s</label>"
                    (org-export-data caption info)))
@@ -1209,7 +1214,10 @@ contextual information."
                    (or (frag-class frag info)
                        (format " class=\"src src-%s\"" lang))
                    (or (frag-index findex) "")
-                   label code)))))))
+                   label code)
+           )
+         (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
+                              lang code) ""))))))
 
 (defun org-reveal-quote-block (quote-block contents info)
   "Transcode a QUOTE-BLOCK element from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -52,6 +52,8 @@
     (:reveal-slide-number nil "reveal_slide_number" org-reveal-slide-number t)
     (:reveal-keyboard nil "reveal_keyboard" org-reveal-keyboard t)
     (:reveal-mousewheel nil "reveal_mousewheel" org-reveal-mousewheel t)
+    (:reveal-fragmentinurl nil "reveal_fragmentinurl" org-reveal-fragmentinurl t)
+    (:reveal-pdfseparatefragments nil "reveal_pdfseparatefragments" org-reveal-pdfseparatefragments t)
     (:reveal-defaulttiming nil "reveal_defaulttiming" org-reveal-defaulttiming t)
     (:reveal-overview nil "reveal_overview" org-reveal-overview t)
     (:reveal-width nil "reveal_width" org-reveal-width t)
@@ -252,6 +254,16 @@ slide, where the following escaping elements are allowed:
 
 (defcustom org-reveal-mousewheel nil
   "Reveal use mousewheel navigation."
+  :group 'org-export-reveal
+  :type 'boolean)
+
+(defcustom org-reveal-fragmentinurl nil
+  "Reveal use fragmentInURL setting."
+  :group 'org-export-reveal
+  :type 'boolean)
+
+(defcustom org-reveal-pdfseparatefragments t
+  "Reveal disable pdfSeparateFragments setting."
   :group 'org-export-reveal
   :type 'boolean)
 
@@ -717,6 +729,8 @@ slideNumber: %s,
 rollingLinks: %s,
 keyboard: %s,
 mouseWheel: %s,
+fragmentInURL: %s,
+pdfSeparateFragments: %s,
 %s
 overview: %s,
 "
@@ -730,6 +744,8 @@ overview: %s,
             (if (plist-get info :reveal-rolling-links) "true" "false")
             (if (plist-get info :reveal-keyboard) "true" "false")
             (if (plist-get info :reveal-mousewheel) "true" "false")
+            (if (plist-get info :reveal-fragmentinurl) "true" "false")
+            (if (plist-get info :reveal-pdfseparatefragments) "true" "false")
             (let ((timing (plist-get info :reveal-defaulttiming)))
 	      (if timing (format "defaultTiming: %s," timing)
 		""))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -68,7 +68,7 @@
     (:reveal-extra-css "REVEAL_EXTRA_CSS" nil org-reveal-extra-css newline)
     (:reveal-extra-js "REVEAL_EXTRA_JS" nil org-reveal-extra-js nil)
     (:reveal-hlevel "REVEAL_HLEVEL" nil nil t)
-    (:reveal-title-slide "REVEAL_TITLE_SLIDE" nil org-reveal-title-slide t)
+    (:reveal-title-slide "REVEAL_TITLE_SLIDE" nil org-reveal-title-slide newline)
     (:reveal-academic-title "REVEAL_ACADEMIC_TITLE" nil nil t)
     (:reveal-miscinfo "REVEAL_MISCINFO" nil nil t)
     (:reveal-slide-global-header nil "reveal_global_header" org-reveal-global-header t)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -139,7 +139,8 @@ When set to `auto', an automatic title slide is generated. When
 set to a string, use this string as a format string for title
 slide, where the following escaping elements are allowed:
 
-  %s stands for the title
+  %t stands for the title.
+  %s stands for the subtitle.
   %a stands for the author's name.
   %e stands for the author's email.
   %d stands for the date.
@@ -335,10 +336,10 @@ content."
           (const multiplex)))
 
 (defcustom org-reveal-external-plugins nil
-  "Additional third-party Plugins to load with reveal. 
-Each entry should contain a name and an expression of the form 
+  "Additional third-party Plugins to load with reveal.
+Each entry should contain a name and an expression of the form
 \"{src: '%srelative/path/from/reveal/root', async:true/false,condition: jscallbackfunction(){}}\"
-Note that some plugins have dependencies such as jquery; these must be included here as well, 
+Note that some plugins have dependencies such as jquery; these must be included here as well,
 BEFORE the plugins that depend on them."
   :group 'org-export-reveal
   :type 'alist)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -32,8 +32,10 @@
 ;;; Code:
 
 (require 'ox-html)
-(require 'cl)
-(require 'cl-extra)
+(require 'cl-extra) ; cl-every
+(require 'cl-lib)   ; cl-mapcar
+(require 'cl-macs)  ; cl-loop, cl-letf
+(require 'subr-x)   ; string-trim
 (require 'url-parse)
 
 (org-export-define-derived-backend 'reveal 'html
@@ -1531,10 +1533,10 @@ transformed fragment attribute to ELEM's attr_html plist."
 		      "Use one audio file per item!  %s has %d, need %d"
 		      frag-audio (length frag-index) itemno))
 	    (if frag-audio
-		(mapcar* 'org-reveal--update-attr-html
-			 items frag-list style-list frag-index frag-audio)
-	      (mapcar* 'org-reveal--update-attr-html
-		       items frag-list style-list frag-index)))
+		(cl-mapcar 'org-reveal--update-attr-html
+			   items frag-list style-list frag-index frag-audio)
+	      (cl-mapcar 'org-reveal--update-attr-html
+			 items frag-list style-list frag-index)))
 	(org-reveal--update-attr-html
 	 elem frag default-style frag-index frag-audio))
       elem)))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1117,8 +1117,12 @@ contextual information."
   "Transcode a QUOTE-BLOCK element from Org to Reveal.
 CONTENTS holds the contents of the block INFO is a plist holding
 contextual information."
-  (format "<blockquote %s>\n%s</blockquote>"
-          (frag-class (org-export-read-attribute :attr_reveal quote-block :frag) info)
+  (format "<blockquote%s>\n%s</blockquote>"
+	  (let ((frag (frag-class (org-export-read-attribute
+				   :attr_reveal quote-block :frag) info)))
+	    (if frag
+		(concat " " frag)
+	      ""))
           contents))
 
 

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1552,17 +1552,16 @@ transformed fragment attribute to ELEM's attr_html plist."
          (file (org-export-output-file-name extension subtreep))
          (clientfile (org-export-output-file-name (concat "_client" extension) subtreep)))
 
-    ; export filename_client HTML file if multiplexing
     (setq client-multiplex nil)
-    (setq retfile (org-export-to-file 'reveal file
-                    async subtreep visible-only body-only ext-plist))
+    (org-export-to-file 'reveal file
+      async subtreep visible-only body-only ext-plist)
 
-    ; export the client HTML file if client-multiplex is set true
-    ; by previous call to org-export-to-file
-    (if (eq client-multiplex t)
+    ;; Export the client HTML file if client-multiplex is set true
+    ;; by previous call to org-export-to-file
+    (if client-multiplex
         (org-export-to-file 'reveal clientfile
           async subtreep visible-only body-only ext-plist))
-    (cond (t retfile))))
+    file))
 
 (defun org-reveal-export-to-html-and-browse
   (&optional async subtreep visible-only body-only ext-plist)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1,6 +1,7 @@
 ;;; ox-reveal.el --- reveal.js Presentation Back-End for Org Export Engine
 
 ;; Copyright (C) 2013 Yujie Wen
+;; Copyright (C) 2017-2019 Jens Lechtenbörger
 
 ;; Author: Yujie Wen <yjwen.ty at gmail dot com>
 ;; Created: 2013-04-27

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -65,7 +65,7 @@
     (:reveal-extra-css "REVEAL_EXTRA_CSS" nil org-reveal-extra-css newline)
     (:reveal-extra-js "REVEAL_EXTRA_JS" nil org-reveal-extra-js nil)
     (:reveal-hlevel "REVEAL_HLEVEL" nil nil t)
-    (:reveal-title-slide nil "reveal_title_slide" org-reveal-title-slide t)
+    (:reveal-title-slide "REVEAL_TITLE_SLIDE" nil org-reveal-title-slide t)
     (:reveal-slide-global-header nil "reveal_global_header" org-reveal-global-header t)
     (:reveal-slide-global-footer nil "reveal_global_footer" org-reveal-global-footer t)
     (:reveal-title-slide-background "REVEAL_TITLE_SLIDE_BACKGROUND" nil nil t)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -469,7 +469,7 @@ included here as well, BEFORE the plugins that depend on them."
   :type 'string)
 
 (defconst org-reveal-klipse-languages
-  '("javascript" "js" "ruby" "scheme" "clojure" "php" "html")
+  '("clojure" "html" "javascript" "js" "php" "python" "ruby" "scheme")
   "List of languages supported by org-reveal.")
 
 (defvar org-reveal--last-slide-section-tag ""
@@ -1288,11 +1288,11 @@ contextual information."
 	    (cond ((or (string= lang "js") (string= lang "javascript"))
 		   "selector_eval_js")
                   ((string= lang "clojure") "selector")
-                  ((string= lang "python") "selector_eval_python_client")
-                  ((string= lang "scheme") "selector_eval_scheme")
-                  ((string= lang "ruby") "selector_eval_ruby")
-                  ((string= lang "php") "selector_eval_php")
                   ((string= lang "html") "selector_eval_html")
+                  ((string= lang "php") "selector_eval_php")
+                  ((string= lang "python") "selector_eval_python_client")
+                  ((string= lang "ruby") "selector_eval_ruby")
+                  ((string= lang "scheme") "selector_eval_scheme")
 		  )))
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -526,7 +526,8 @@ Do nothing if \"class\" attribute is alredy present."
   (let ((match (string-match "^<h[1-9][^>]+>" elem)))
     (unless match (error "Element no headline: %s" elem))
     (let ((tag (match-string 0 elem)))
-      (unless (string-match "class" tag)
+      (if (string-match "class" tag)
+	  elem
 	(replace-regexp-in-string "\\(<h[1-9][^>]+\\)>"
 				  (format "\\1 class=\"%s\">" value)
 				  elem)))))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -733,7 +733,9 @@ using custom variable `org-reveal-root'."
 (defun org-reveal--read-file-as-string (filename)
   "If FILENAME exists as file, return its contents as string.
 Otherwise, return nil."
-  (when (and (stringp filename) (file-readable-p filename))
+  (when (and (stringp filename)
+	     (file-readable-p filename)
+	     (not (file-directory-p filename)))
     (with-temp-buffer
       (insert-file-contents-literally filename)
       (buffer-string))))
@@ -1422,7 +1424,7 @@ info is a plist holding export options."
 		  (concat " data-state=\"" title-slide-state "\""))
 		 (when title-slide-timing
 		  (concat " data-timing=\"" title-slide-timing "\""))
-                 ">"
+                 ">\n"
                  (when title-slide-with-header
                    (let ((header (plist-get info :reveal-slide-header)))
                      (when header (format org-reveal-slide-header-html header))))

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -5,7 +5,7 @@
 ;; Author: Yujie Wen <yjwen.ty at gmail dot com>
 ;; Created: 2013-04-27
 ;; Version: 1.0
-;; Package-Requires: ((org "20150330"))
+;; Package-Requires: ((org "8.3"))
 ;; Keywords: outlines, hypermedia, slideshow, presentation
 
 ;; This file is not part of GNU Emacs.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -57,7 +57,7 @@
     (:reveal-defaulttiming nil "reveal_defaulttiming" org-reveal-defaulttiming t)
     (:reveal-overview nil "reveal_overview" org-reveal-overview t)
     (:reveal-width nil "reveal_width" org-reveal-width t)
-    (:reveal-height nil "reveal_height" org-reveal-height)
+    (:reveal-height nil "reveal_height" org-reveal-height t)
     (:reveal-margin "REVEAL_MARGIN" nil org-reveal-margin t)
     (:reveal-min-scale "REVEAL_MIN_SCALE" nil org-reveal-min-scale t)
     (:reveal-max-scale "REVEAL_MAX_SCALE" nil org-reveal-max-scale t)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1192,6 +1192,12 @@ contextual information."
                       (format " id=\"%s\"" lbl))))
            (klipsify  (and (assoc 'klipse org-reveal-external-plugins)
                            (member lang '("javascript" "ruby" "scheme" "clojure" "php"))))
+           (langselector (cond ((string= lang "javascript") "selector_eval_js")
+                               ((string= lang "clojure") "selector")
+                               ((string= lang "python") "selector_eval_python_client")
+                               ((string= lang "scheme") "selector_eval_scheme")
+                               ((string= lang "ruby") "selector_eval_ruby"))
+                         )
            ;;(klipse-hidden (if (assoc 'klipse org-reveal-external-plugins) " style=\"display:hidden;\"") nil)
                       )
       (if (not lang)
@@ -1199,6 +1205,7 @@ contextual information."
                   (or (frag-class frag info) " class=\"example\"")
                   label
                   code)
+        (cond ((eq lang "javascript ")))
         (format
          "<div %sclass=\"org-src-container\">\n%s%s\n</div>%s"
          (if klipsify "style=\"display:none;\" " "")
@@ -1216,8 +1223,22 @@ contextual information."
                    (or (frag-index findex) "")
                    label code)
            )
-         (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
-                              lang code) ""))))))
+         ;; (if klipsify (format "<klipse-snippet data-language=\"%s\">%s</klipse-snippet>"
+         ;;                      lang code) "")
+         (if klipsify (concat  "<iframe height=\"500px\" width= \"100%\" srcdoc='
+<pre><code class= \"klipse\">
+" code  "
+</code></pre>
+<link rel= \"stylesheet\" type= \"text/css\" href=\"" org-reveal-klipse-css "\">
+<style>
+.CodeMirror { font-size: 2em; }
+</style>
+<script>
+window.klipse_settings = { " langselector  ": \".klipse\" };
+</script>
+<script src= \"" org-reveal-klipse-js "\"></script>
+'>
+</iframe>") "") )))))
 
 (defun org-reveal-quote-block (quote-block contents info)
   "Transcode a QUOTE-BLOCK element from Org to Reveal.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -877,19 +877,23 @@ holding export options."
    ;; Document contents.
    contents))
 
-(defun org-reveal-parse-token (key &optional value)
-  "Return HTML tags or perform SIDE EFFECT according to key.
-Use the previous section tag as the tag of the split section. "
+(defun org-reveal-parse-token (footer key &optional value)
+  "Return HTML tags or perform SIDE EFFECT according to KEY.
+Currently, only splitting of slides/sections is implemented.
+The current section is closed by FOOTER, which may be nil.
+use the previous section tag as the tag of the split section. "
   (case (intern key)
-    (split (format "</section>\n%s" org-reveal--last-slide-section-tag))))
+    (split (format "%s</section>\n%s"
+		   footer org-reveal--last-slide-section-tag))))
 
-(defun org-reveal-parse-keyword-value (value)
-  "According to the value content, return HTML tags to split slides."
+(defun org-reveal-parse-keyword-value (value footer)
+  "According to the VALUE content, return HTML tags to split slides.
+The possibly empty FOOTER is inserted at the end of the slide."
   (let ((tokens (mapcar
                  (lambda (x) (split-string x ":"))
                  (split-string value))))
     (mapconcat
-     (lambda (x) (apply 'org-reveal-parse-token x))
+     (lambda (x) (apply 'org-reveal-parse-token footer x))
      tokens
      "")))
 
@@ -962,7 +966,7 @@ CONTENTS is nil. INFO is a plist holding contextual information."
 	 (footer-div (when footer
 		       (format org-reveal-slide-footer-html footer))))
     (case (intern key)
-      (REVEAL (org-reveal-parse-keyword-value value))
+      (REVEAL (org-reveal-parse-keyword-value value footer-div))
       (REVEAL_HTML value)
       (HTML value)
       ;; Handling of TOC at arbitrary position is a hack.

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -814,7 +814,7 @@ dependencies: [
 	   (toc (replace-regexp-in-string
 		 (org-html--translate "Table of Contents" info)
 		 toc-slide-title toc)))
-      (concat "<section id=\"table-of-contents\""
+      (concat "<section id=\"table-of-contents-section\""
 	      (when toc-slide-state
 		(format " data-state=\"%s\"" toc-slide-state))
 	      ">\n"

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1188,9 +1188,6 @@ holding contextual information."
   "Transcode a SRC-BLOCK element from Org to Reveal.
 CONTENTS holds the contents of the item.  INFO is a plist holding
 contextual information."
-  (message  "%s" (plist-get (cadr src-block) :attr_html))
-  (if (org-export-read-attribute :attr_html src-block :data-library)
-      (message "could do something useful here with the data-library element"))
   (if (org-export-read-attribute :attr_html src-block :textarea)
       (org-html--textarea-block src-block)
     (let* ((use-highlight (org-reveal--using-highlight.js info))
@@ -1217,18 +1214,7 @@ contextual information."
                                ((string= lang "ruby") "selector_eval_ruby")
                                ((string= lang "html") "selector_eval_html"))
                          )
-           (attributes  (org-export-read-attribute :attr_html src-block))
-           ;; this was an idea to collect attributes -- doesn't seem to make sense.
-           ;; (extra-atts (if klipsify
-           ;;                 ;; (cl-loop for (key  value) in attributes
-           ;;                 ;;          collect (format "%s=\"%s\"" key value))
-           ;;                 ;; (message "oops not klipsify")
-           ;;                 ""
-           ;;               ""))
-               )
-      ;; debugging messages, no longer necessary
-      ;; (message "html attributes=%s" attributes)
-      ;; (message "html code attribsis a %s" (stringp (org-export-read-attribute :attr_html src-block :class)))
+)
       (if (not lang)
           (format "<pre %s%s>\n%s</pre>"
                   (or (frag-class frag info) " class=\"example\"")

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1010,8 +1010,8 @@ CONTENTS is nil. INFO is a plist holding contextual information."
 	 (toc-html (org-reveal-toc-1
 		    (org-html-keyword keyword contents info) info))
 	 (footer (plist-get info :reveal-slide-footer))
-	 (footer-div (when footer
-		       (format org-reveal-slide-footer-html footer))))
+	 (footer-div (if footer
+		       (format org-reveal-slide-footer-html footer) "")))
     (case (intern key)
       (REVEAL (org-reveal-parse-keyword-value value footer-div))
       (REVEAL_HTML value)

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1267,7 +1267,8 @@ contextual information."
            (caption (org-export-get-caption src-block))
            (code (if (not use-highlight)
                      (org-html-format-code src-block info)
-                   (cl-letf (((symbol-function 'org-html-htmlize-region-for-paste)
+                   (cl-letf (((symbol-function
+			       'org-html-htmlize-region-for-paste)
                               #'buffer-substring))
                      (org-html-format-code src-block info))))
            (frag (org-export-read-attribute :attr_reveal src-block :frag))
@@ -1277,7 +1278,7 @@ contextual information."
            (label (let ((lbl (org-element-property :name src-block)))
                     (if (not lbl) ""
                       (format " id=\"%s\"" lbl))))
-           (klipsify  (and  org-reveal-klipsify-src
+           (klipsify  (and org-reveal-klipsify-src
                            (member lang '("javascript" "js" "ruby" "scheme" "clojure" "php" "html"))))
            (langselector (cond ((or (string= lang "js") (string= lang "javascript")) "selector_eval_js")
                                ((string= lang "clojure") "selector")
@@ -1299,23 +1300,29 @@ contextual information."
 		 "data-editor-type=\"html\" "
 	       "")
 	     "class=\"klipse\" " code-attribs ">
-" (if (string= lang "html")
-      (replace-regexp-in-string "'" "&#39;"
-                                (replace-regexp-in-string "&" "&amp;"
-                                                          (replace-regexp-in-string "<" "&lt;"
-                                                                                    (replace-regexp-in-string ">" "&gt;"
-                                                                                                              (cl-letf (((symbol-function 'org-html-htmlize-region-for-paste)
-                                                                                                                         #'buffer-substring))
-                                                                                                                (org-html-format-code src-block info))))))
-    (replace-regexp-in-string "'" "&#39;"
-                              code))  "
+"
+	     (if (string= lang "html")
+		 (replace-regexp-in-string
+		  "'" "&#39;"
+                  (replace-regexp-in-string
+		   "&" "&amp;"
+                   (replace-regexp-in-string
+		    "<" "&lt;"
+                    (replace-regexp-in-string
+		     ">" "&gt;"
+                     (cl-letf (((symbol-function
+				 'org-html-htmlize-region-for-paste)
+                                #'buffer-substring))
+                       (org-html-format-code src-block info))))))
+	       (replace-regexp-in-string "'" "&#39;" code))
+	     "
 </code></pre>
 <link rel= \"stylesheet\" type= \"text/css\" href=\"" org-reveal-klipse-css "\">
 <style>
 .CodeMirror { font-size: 2em; }
 </style>
 <script>
-window.klipse_settings = { " langselector  ": \".klipse\" };
+window.klipse_settings = { " langselector ": \".klipse\" };
 </script>
 <script src= \"" org-reveal-klipse-js "\"></script></body></html>
 '>

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1295,7 +1295,10 @@ contextual information."
         (if klipsify
             (concat
              "<iframe style=\"background-color:white;\" height=\"500px\" width= \"100%\" srcdoc='<html><body><pre><code "
-             (if (string= lang "html" )"data-editor-type=\"html\"  "  "") "class=\"klipse\" "code-attribs ">
+             (if (string= lang "html")
+		 "data-editor-type=\"html\" "
+	       "")
+	     "class=\"klipse\" " code-attribs ">
 " (if (string= lang "html")
       (replace-regexp-in-string "'" "&#39;"
                                 (replace-regexp-in-string "&" "&amp;"

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1099,7 +1099,15 @@ info is a plist holding export options."
                    (let ((header (plist-get info :reveal-slide-header)))
                      (when header (format "<div class=\"slide-header\">%s</div>\n" header))))
                  (cond ((eq title-slide nil) nil)
-                       ((stringp title-slide) (format-spec title-slide (org-html-format-spec info)))
+                       ((stringp title-slide)
+			(let ((title-string
+			       (if (file-readable-p title-slide)
+				   (with-temp-buffer
+				     (insert-file-contents-literally title-slide)
+				     (buffer-string))
+				 title-slide)))
+			  (format-spec title-string
+				       (org-html-format-spec info))))
                        ((eq title-slide 'auto) (org-reveal--auto-title-slide-template info)))
                  "\n"
                  (when title-slide-with-footer

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1285,6 +1285,7 @@ contextual information."
                                ((string= lang "python") "selector_eval_python_client")
                                ((string= lang "scheme") "selector_eval_scheme")
                                ((string= lang "ruby") "selector_eval_ruby")
+                               ((string= lang "php") "selector_eval_php")
                                ((string= lang "html") "selector_eval_html"))
                          )
 )

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1592,7 +1592,9 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+	       (if (version< org-version "9.2")
+		   (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")
+		 (cons org-reveal-note-key-char "notes"))))
 
 (provide 'ox-reveal)
 


### PR DESCRIPTION
Many thanks for org-reveal!

This pull request adds more options for the generation of title slides and TOC slides.
Also fragmented lists were not working properly for me.  This is fixed now, and fragments can now have audio to used with the audio plugin of [reveal.js-plugins](https://github.com/rajgoel/reveal.js-plugins). (I pushed another branch with test files.)