### PR TITLE
Disable section numbers by default for reveal-exports

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -696,11 +696,11 @@ Store the names and loading instructions for each plugin in the defcustom ~org-r
 
 * Tips
 
-** Disable Heading Numbers
-
-   Add =num:nil= to =#+OPTIONS=
+** Enable Heading Numbers
+Heading numbers are disabled by default for org-reveal exports. 
+For enabling them, add =num:t= to =#+OPTIONS=
 #+BEGIN_SRC org
-,#+OPTIONS: num:nil
+,#+OPTIONS: num:t
 #+END_SRC
 
 ** Internal Links

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -91,6 +91,7 @@
     (:reveal-single-file nil "reveal_single_file" org-reveal-single-file t)
     (:reveal-init-script "REVEAL_INIT_SCRIPT" nil org-reveal-init-script space)
     (:reveal-highlight-css "REVEAL_HIGHLIGHT_CSS" nil org-reveal-highlight-css nil)
+    (:section-numbers nil "num" nil)
     )
 
   :translate-alist


### PR DESCRIPTION
I believe that it is fairly uncommon for people wanting to include numbers in the headings in presentations. This is a way of disabling it by default and avoiding everyone having to disable it in every file with `#+OPTIONS: num:nil` or by setting `org-export-with-section-numbers` (which would affect all other kinds of exports).

See this as a suggestion, and feel free to ignore it if you disagree or if it would be disrupting to users or anything.