### PR TITLE
Update on Readme.org

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -229,7 +229,9 @@
 *** Customize the Title Slide
 
     To customize the title slide, please set ~org-reveal-title-slide~
-    to a string of HTML markups. The following escaping character can
+    to a string of HTML markups. Alternatively, set ~reveal_title_slide~ in 
+    the ~#+OPTIONS:~ line to a string of HTML markups. 
+    The following escaping character can
     be used to retrieve document information:
     | ~%t~ | Title     |
     | ~%a~ | Author    |


### PR DESCRIPTION
Changing the variable org-reveal-title-slide never worked for me, but changing reveal_title_slide in the options does work correctly. I added a comment for reveal_title_slide in the Readme.org file to make it clear that there is an alternative way (that actually works) to change the title slide.