### PR TITLE
Readme.org: Properties for Sub-headings

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -721,6 +721,43 @@ Store the names and loading instructions for each plugin in the defcustom ~org-r
    ~#+REVEAL_INIT_SCRIPT~ (multiple statements are concatenated) or by
    custom variable ~org-reveal-init-script~.
 
+** Properties for Sub-headings
+
+If you want to have multiple reveal presentations in a single Org-mode 
+file, you might want to switch from file-based properties like: 
+
+#+BEGIN_SRC org
+,#+REVEAL_HLEVEL: 2
+,#+REVEAL_TRANS: cube
+,#+REVEAL_THEME: moon
+#+END_SRC
+
+to properties of sub-headings like:
+
+#+BEGIN_SRC org
+:PROPERTIES:
+:EXPORT_REVEAL_HLEVEL: 2
+:EXPORT_REVEAL_TRANS: cube
+:EXPORT_REVEAL_THEME: moon
+:END:
+#+END_SRC
+
+This way, each org-reveal presentation can have its own settings. An example heading with corresponding settings would look like:
+
+#+BEGIN_SRC org
+* My org-reveal presentation among many within the same Org-mode file
+:PROPERTIES:
+:reveal_overview: t
+:EXPORT_AUTHOR: Test Author
+:EXPORT_DATE: 2018-01-01
+:EXPORT_TITLE: My Title
+:EXPORT_EMAIL: Test@example.com
+:EXPORT_OPTIONS: num:nil toc:nil reveal_keyboard:t reveal_overview:t
+:EXPORT_REVEAL_HLEVEL: 3
+:EXPORT_REVEAL_MARGIN: 200
+:END:
+#+END_SRC
+
 * Thanks
 
   Courtesy to:


### PR DESCRIPTION
Additional to file-based properties, users are able to use heading-based properties in order to have multiple different presentations within one single org-mode file.