### PR TITLE
Fix the way that we set up the Org template for notes.

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1228,7 +1228,7 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+               (cons org-reveal-note-key-char "notes")))
 
 (provide 'ox-reveal)
 


### PR DESCRIPTION
The way that Org does templates has changed. "<*"-style templates now require
the org-tempo package, and org-structure-template-alist has changed. Now it is
a list of cons pairs of the form "(key . block-name)". This creates an
expansion from "<key" to "#+begin_block-name\n\n#+end_block-name".