### PR TITLE
Change Package-Requires to use an org-mode release version.

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -5,7 +5,7 @@
 ;; Author: Yujie Wen <yjwen.ty at gmail dot com>
 ;; Created: 2013-04-27
 ;; Version: 1.0
-;; Package-Requires: ((org "20150330"))
+;; Package-Requires: ((org "8.3"))
 ;; Keywords: outlines, hypermedia, slideshow, presentation
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
Depending on an org timestamp makes ox-reveal uninstallable via
melpa if org is installed by any means that uses release versions.