### PR TITLE
 Suggestion: Include bibliography from org-ref at the end of the slideshow

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1292,7 +1292,7 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+               (list org-reveal-note-key-char "NOTES")))
 
 (provide 'ox-reveal)
 

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -963,11 +963,15 @@ Extract and set `attr_html' to plain-list tag attributes."
             )))
 
 (defun org-reveal--insert-bibliography (&optional ignore)
-  "Create a slide for the bibliography from org-ref"
-  (concat "<section>"
-          (funcall 'org-ref-get-html-bibliography)
-          "</section>"
-  ))
+  "Create a slide for the bibliography from org-ref, if it exists"
+  (if (fboundp 'org-ref-get-html-bibliography)
+      (progn 
+        ;; here we could employ other bibliographic engines
+        (fset 'bibliography 'org-ref-get-html-bibliography)
+        (when (funcall 'bibliography)
+            (concat "<section>"
+                    (funcall 'bibliography)
+                    "</section>")))))
 
 (defun org-reveal--build-pre/postamble (type info)
   "Return document preamble or postamble as a string, or nil."

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -962,6 +962,13 @@ Extract and set `attr_html' to plain-list tag attributes."
             tag
             )))
 
+(defun org-reveal--insert-bibliography (&optional ignore)
+  "Create a slide for the bibliography from org-ref"
+  (concat "<section>"
+          (funcall 'org-ref-get-html-bibliography)
+          "</section>"
+  ))
+
 (defun org-reveal--build-pre/postamble (type info)
   "Return document preamble or postamble as a string, or nil."
   (let ((section (plist-get info (intern (format ":reveal-%s" type))))
@@ -1158,6 +1165,7 @@ info is a plist holding export options."
                      (when footer (format "<div class=\"slide-footer\">%s</div>\n" footer))))
                  "</section>\n"))))
    contents
+   (org-reveal--insert-bibliography)
    "</div>
 </div>\n"
    (org-reveal--build-pre/postamble 'postamble info)


### PR DESCRIPTION
Addresses #336.  This suggestion is different than #248. I would like my org-ref bibliography to be included at the end of my slideshow.

The code relevant in this pull request first check to see if the `org-ref-get-html-bibliography` function exists. If it does, we check if it returns non-nil (there is a bibliography). I've set it up so that if someone wishes another bibliographic engine, perhaps with a #+reveal directive, we could set the `bibliography` symbol to that function.

Tested and working for me on org documents that have a bibliography and that don't (with expected behavior of slide or no slide), as well as if org-ref is not installed (do nothing).