### PR TITLE
Use new format for org-structure-template-alist items

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1280,7 +1280,7 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+               (cons org-reveal-note-key-char "notes")))
 
 (provide 'ox-reveal)
 


### PR DESCRIPTION
Upstream org-mode has changed the format of entries in org-structure-template-alist, apparently for emacs 27.1. Adjust for compatibility.