### PR TITLE
support org version 9.2

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1280,7 +1280,9 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+               (if (version< org-version "9.2")
+                   (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")
+                 (cons org-reveal-note-key-char "notes"))))
 
 (provide 'ox-reveal)
 


### PR DESCRIPTION
The format of org-structure-template-alist changed in the newer version.