### PR TITLE
Trim long exported code blocks

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1060,7 +1060,7 @@ window.klipse_settings = { " langselector  ": \".klipse\" };
                 (format "\n<pre%s%s><code class=\"%s\" %s>%s</code></pre>"
                         (or (frag-class frag info) "")
                         label lang code-attribs code)
-              (format "\n<pre %s%s>%s</pre>"
+              (format "\n<pre %s%s><code trim>%s</code></pre>"
                       (or (frag-class frag info)
                           (format " class=\"src src-%s\"" lang))
                       label code)


### PR DESCRIPTION
When using highlight js one can trim by using html but when exporting code blocks and using htmlize.el this doesn't seem possible.