### PR TITLE
New org-structure-template-alist entry format

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -1280,7 +1280,7 @@ Return output file name."
 ;; Register auto-completion for speaker notes.
 (when org-reveal-note-key-char
   (add-to-list 'org-structure-template-alist
-               (list org-reveal-note-key-char "#+BEGIN_NOTES\n\?\n#+END_NOTES")))
+               `(,org-reveal-note-key-char . "notes")))
 
 (provide 'ox-reveal)
 


### PR DESCRIPTION
Warning (org): 
Please update the entries of `org-structure-template-alist'.

In Org 9.2 the format was changed from something like

    ("s" "#+BEGIN_SRC ?\n#+END_SRC")

to something like

    ("s" . "src")

Please refer to the documentation of `org-structure-template-alist'.

The following entries must be updated:

(("n" "#+BEGIN_NOTES\n?\n#+END_NOTES"))

