### PR TITLE
Support the "data-state" attribute on the title slide

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -37,6 +37,7 @@
     - [[Select Theme][Select Theme]]([[https://github.com/yjwen/org-reveal#select-theme][gh]])
     - [[Set The Title Slide][Set The Title Slide]]([[https://github.com/yjwen/org-reveal#set-the-title-slide][gh]])
       - [[Customize the Title Slide][Customize the Title Slide]]([[https://github.com/yjwen/org-reveal#customize-the-title-slide][gh]])
+      - [[Title Slide State][Title Slide State]]([[https://github.com/yjwen/org-reveal#title-slide-state][gh]])
     - [[Set Slide Background][Set Slide Background]]([[https://github.com/yjwen/org-reveal#set-slide-background][gh]])
       - [[Single Colored Background][Single Colored Background]]([[https://github.com/yjwen/org-reveal#single-colored-background][gh]])
       - [[Single Image Background][Single Image Background]]([[https://github.com/yjwen/org-reveal#single-image-background][gh]])
@@ -316,6 +317,14 @@ Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
     | ~%d~ | Date      |
     | ~%%~ | Literal % |
 
+*** Title Slide State
+
+    Using this option allows to thoroughly change the style of the title slide:
+
+    * =REVEAL_TITLE_SLIDE_STATE=: Style applied to the [[https://revealjs.com/markup/#viewport][viewport]] of title slide.
+      See the [[https://revealjs.com/markup/#slide-states][reveal.js documentation]]
+      for details.
+
 ** Set Slide Background
 
    Slide background can be set to a color, an image, a repeating image
@@ -405,6 +414,7 @@ Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
     * =REVEAL_TITLE_SLIDE_BACKGROUND_SIZE=: HTML size specification, e.g. ~200px~.
     * =REVEAL_TITLE_SLIDE_BACKGROUND_REPEAT=: Set to ~repeat~ to repeat the image.
     * =REVEAL_TITLE_SLIDE_BACKGROUND_OPACITY=: Set the background opacity.
+
 *** Table of Contents Slide Background Image
 
     To set the (automatically generated) table of contents slide's background

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -73,6 +73,7 @@
     (:reveal-title-slide-background-repeat "REVEAL_TITLE_SLIDE_BACKGROUND_REPEAT" nil nil t)
     (:reveal-title-slide-background-transition "REVEAL_TITLE_SLIDE_BACKGROUND_TRANSITION" nil nil t)
     (:reveal-title-slide-background-opacity "REVEAL_TITLE_SLIDE_BACKGROUND_OPACITY" nil nil t)
+    (:reveal-title-slide-state "REVEAL_TITLE_SLIDE_STATE" nil nil t)
     (:reveal-toc-slide-background "REVEAL_TOC_SLIDE_BACKGROUND" nil nil t)
     (:reveal-toc-slide-background-size "REVEAL_TOC_SLIDE_BACKGROUND_SIZE" nil nil t)
     (:reveal-toc-slide-background-position "REVEAL_TOC_SLIDE_BACKGROUND_POSITION" nil nil t)
@@ -1401,6 +1402,7 @@ info is a plist holding export options."
              (title-slide-background-repeat (plist-get info :reveal-title-slide-background-repeat))
              (title-slide-background-transition (plist-get info :reveal-title-slide-background-transition))
 	     (title-slide-background-opacity (plist-get info :reveal-title-slide-background-opacity))
+             (title-slide-state (plist-get info :reveal-title-slide-state))
              (title-slide-with-header (plist-get info :reveal-slide-global-header))
              (title-slide-with-footer (plist-get info :reveal-slide-global-footer)))
          (concat "<section id=\"sec-title-slide\""
@@ -1416,6 +1418,8 @@ info is a plist holding export options."
                    (concat " data-background-transition=\"" title-slide-background-transition "\""))
 		 (when title-slide-background-opacity
 		   (concat " data-background-opacity=\"" title-slide-background-opacity "\""))
+                 (when title-slide-state
+		   (concat " data-state=\"" title-slide-state "\""))
                  ">"
                  (when title-slide-with-header
                    (let ((header (plist-get info :reveal-slide-header)))


### PR DESCRIPTION
I wanted to style the title slide differently than the rest of the presentation.  Examining the reveal.js documentation I found the `data-state` attribute, which is just what I need.  This PR adds support for it in *org-reveal*.  Thank you!