### PR TITLE
Custom theme

### DIFF
--- a/Readme.org
+++ b/Readme.org
@@ -278,15 +278,18 @@
 Theme is set globally throughout the whole file by setting option
 =REVEAL_THEME=.
 
+Available themes can be found in "css/theme/" in the reveal.js directory.
+
+Custom themes can be implemented by setting =REVEAL_THEME= to =custom= and
+then setting =REVEAL_THEME_CUSTOM= to the path for a theme CSS file.
+
 Slide transition style is set by initialization option ~transition~
 and the transition speed is set by ~transitionSpeed~ . Please refer to
 section [[Initialization options]] for details.
 
-For an example, please check the heading part of this document.
-
-Available themes can be found in "css/theme/" in the reveal.js directory.
-
 Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
+
+For an example of these settings, please check the heading part of this document.
 ** Set The Title Slide
    By default, Org-reveal generates a title slide displaying the
    title, the author, the Email, the date and the time-stamp of the

--- a/Readme.org
+++ b/Readme.org
@@ -303,11 +303,11 @@ Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
 
     There are 3 ways to customize the title slide.
 
-    1. Set variable ~org-reveal-title-slide~ to a string of HTML markups. 
+    1. Set variable ~org-reveal-title-slide~ to a string of HTML markups.
     2. Set ~reveal_title_slide~ in the ~#+OPTIONS:~ line to a string of HTML markups.
     3. Use one or more option lines ~#+REVEAL_TITLE_SLIDE:~ to specify
        the HTML of the title slide.
-       
+
     The following escaping characters can be used to retrieve document
     information:
     | ~%t~ | Title     |
@@ -453,7 +453,7 @@ Available transitions are: default|cube|page|concave|zoom|linear|fade|none.
         ratio.
 
 ** Slide Numbering
-   
+
 To enable slide numbers, please add the following Reveal.js initial option.
 #+BEGIN_SRC org
 ,#+REVEAL_INIT_OPTIONS: slideNumber:true
@@ -614,7 +614,7 @@ be replaced by Reveal.js root path.
    To Use your Emacs theme, please make sure ~htmlize.el~ is
    installed. Then no more setup is necessary.
 
-   Below is an example of highlighted lisp code from org-reveal. 
+   Below is an example of highlighted lisp code from org-reveal.
    #+BEGIN_SRC lisp
      (defun org-reveal--read-file (file)
        "Return the content of file"
@@ -684,14 +684,14 @@ int main()
        ,#+end_src
 
    #+end_src
-   
+
 
 ** Editable Source Code
 It is now possible to embed code blocks in a codemirror instance in order to edit code during a presentation.  At present, this capacity is turned on or off at time export using these defcustoms:
 - ~org-reveal-klipsify-src~
 - ~org-reveal-klipse-css~
 - ~org-reveal-klipse-js~
-This feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present code editing is supported in javascript, clojure, php, ruby, scheme, and python only.  
+This feature is turned off by default and needs to be switched on with ~org-reveal-klipsify-src~.  At present code editing is supported in javascript, clojure, php, ruby, scheme, and python only.
 
 ** MathJax
   :PROPERTIES:
@@ -936,7 +936,7 @@ To disable the automatic TOC, add =toc:nil= to =#+OPTIONS=
    the closing ~</script>~ tag.
 
 ** Executable Source Blocks
-To allow live execution of code in some languages, enable the klipse plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.  
+To allow live execution of code in some languages, enable the klipse plugin by setting ~org-reveal-klipsify-src~ to non-nil.  Src blocks with the languages ~js~, ~clojure~, ~html~, ~python~, ~ruby~, ~scheme~, ~php~ will be executed with output shown in a console-like environment.  See the source code of ~org-reveal-src-block~ for more details.
 
 *** HTML Src Block
 #+BEGIN_SRC html

--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -60,6 +60,7 @@
     (:reveal-trans "REVEAL_TRANS" nil nil t)
     (:reveal-speed "REVEAL_SPEED" nil nil t)
     (:reveal-theme "REVEAL_THEME" nil org-reveal-theme t)
+    (:reveal-theme-custom "REVEAL_THEME_CUSTOM" nil nil nil)
     (:reveal-extra-css "REVEAL_EXTRA_CSS" nil org-reveal-extra-css newline)
     (:reveal-extra-js "REVEAL_EXTRA_JS" nil org-reveal-extra-js nil)
     (:reveal-extra-initial-js "REVEAL_EXTRA_INITIAL_JS" nil org-reveal-extra-initial-js newline)
@@ -638,10 +639,12 @@ using custom variable `org-reveal-root'."
          (version (org-reveal--get-reveal-js-version info))
          (reveal-css (org-reveal--choose-path root-path version "dist/reveal.css" "css/reveal.css"))
          (theme (plist-get info :reveal-theme))
-         (theme-css (org-reveal--choose-path root-path
-                                             version
-                                             (concat "dist/theme/" theme ".css")
-                                             (concat "css/theme/" theme ".css")))
+         (theme-css (if (string-equal "custom" (downcase theme))
+                        (plist-get info :reveal-theme-custom)
+                      (org-reveal--choose-path root-path
+                                               version
+                                               (concat "dist/theme/" theme ".css")
+                                               (concat "css/theme/" theme ".css"))))
          (extra-css (plist-get info :reveal-extra-css))
          (in-single-file (plist-get info :reveal-single-file)))
     (concat


### PR DESCRIPTION
This PR implements the ability to select a custom theme. If the `REVEAL_THEME` option is set to `custom`, then the `REVEAL_THEME_CUSTOM` option can be used to specify the path to a theme CSS file.