### PR TITLE
Support multiple stylesheets in EXPORT_REVEAL_EXTRA_CSS separated by spaces

### DIFF
--- a/ox-reveal.el
+++ b/ox-reveal.el
@@ -672,7 +672,7 @@ using custom variable `org-reveal-root'."
                 (append (list (cons reveal-css nil)
                               (cons theme-css "theme"))
                         (mapcar (lambda (a) (cons a nil))
-                                (split-string extra-css "\n")))
+                                (split-string extra-css "[ \t\n]+")))
                 "\n")
 
      ;; Include CSS for highlight.js if necessary


### PR DESCRIPTION
Change the splitting of EXPORT_REVEAL_EXTRA_CSS to also support spaces. This addresses the issue reported in #490.